### PR TITLE
Post as actual Matrix user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,4 @@ tsconfig.tsbuildinfo
 .externalToolBuilders/
 
 /public
-
-wporg-user-mapping.csv
+wporg-users/

--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,3 @@ tsconfig.tsbuildinfo
 .externalToolBuilders/
 
 /public
-wporg-users/

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ tsconfig.tsbuildinfo
 .externalToolBuilders/
 
 /public
+
+wporg-user-mapping.csv

--- a/src/BaseSlackHandler.ts
+++ b/src/BaseSlackHandler.ts
@@ -200,7 +200,7 @@ export abstract class BaseSlackHandler {
             const id = match[1];
 
             let displayName = "";
-            const userId = this.main.ghostStore.getUserId(id, teamDomain);
+            const userId = await this.main.ghostStore.getUserId(id, teamDomain);
 
             const users = await this.main.datastore.getUser(userId);
 

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -740,6 +740,14 @@ export class Main {
         this.incCounter(METRIC_RECEIVED_MESSAGE, {side: "matrix"});
         const endTimer = this.startTimer("matrix_request_seconds");
 
+        // Do not post echoes back to Slack.
+        const existingEvent = await this.datastore.getEventByMatrixId(ev.room_id, ev.event_id);
+        if (existingEvent) {
+            log.debug("Ignoring existing event", ev.event_id, ev.room_id);
+            endTimer({outcome: "dropped"});
+            return;
+        }
+
         // Admin room message
         if (ev.room_id === this.config.matrix_admin_room &&
             ev.type === "m.room.message") {

--- a/src/SlackGhostStore.ts
+++ b/src/SlackGhostStore.ts
@@ -54,7 +54,17 @@ export class SlackGhostStore {
         return (await nullGhost.getDisplayname(room!.SlackClient!)) || userId;
     }
 
-    public getUserId(id: string, teamDomain: string): string {
+    public async getUserId(id: string, teamDomain: string): Promise<string> {
+        if (["wordpress", "orbit-sandbox"].includes(teamDomain)) {
+            const wporgUsername = await this.datastore.getWporgUsername(id);
+            if (wporgUsername) {
+                log.info("Found wporg username:", wporgUsername, id);
+                return `@${wporgUsername}:${this.config.homeserver.server_name}`;
+            } else {
+                log.info("Could not find wporg username for", id);
+            }
+        }
+
         const localpart = `${this.config.username_prefix}${teamDomain.toLowerCase()}_${id.toUpperCase()}`;
         return `@${localpart}:${this.config.homeserver.server_name}`;
     }

--- a/src/SlackGhostStore.ts
+++ b/src/SlackGhostStore.ts
@@ -77,7 +77,7 @@ export class SlackGhostStore {
 
         const domain = teamDomain || await this.getTeamDomainForMessage({}, teamId);
 
-        const userId = this.getUserId(
+        const userId = await this.getUserId(
             slackUserId,
             domain,
         );

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -271,7 +271,7 @@ export class TeamSyncer {
 
     public async syncUser(teamId: string, domain: string, item: ISlackUser): Promise<void> {
         log.info(`Syncing user ${teamId} ${item.id}`);
-        const existingGhost = await this.main.ghostStore.getExisting(this.main.ghostStore.getUserId(item.id, domain));
+        const existingGhost = await this.main.ghostStore.getExisting(await this.main.ghostStore.getUserId(item.id, domain));
         if (item.deleted && !existingGhost) {
             // This is a deleted user that we've never seen, bail.
             return;

--- a/src/datastore/Models.ts
+++ b/src/datastore/Models.ts
@@ -96,6 +96,7 @@ export interface Datastore extends ProvisioningStore {
     upsertUser(user: SlackGhost): Promise<null>;
     getUser(id: string): Promise<UserEntry|null>;
     getMatrixUser(userId: string): Promise<MatrixUser|null>;
+    getWporgUsername(slackUserId: string): Promise<string|null>;
     storeMatrixUser(user: MatrixUser): Promise<null>;
     getAllUsersForTeam(teamId: string): Promise<UserEntry[]>;
 

--- a/src/datastore/NedbDatastore.ts
+++ b/src/datastore/NedbDatastore.ts
@@ -167,6 +167,10 @@ export class NedbDatastore implements Datastore {
         return (await this.userStore.getMatrixUser(userId)) || null;
     }
 
+    public async getWporgUsername(slackUserId: string): Promise<string|null> {
+        return null;
+    }
+
     public async storeMatrixUser(user: MatrixUser): Promise<null> {
         await this.userStore.setMatrixUser(user);
         return null;

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -271,7 +271,7 @@ export class PgDatastore implements Datastore, ClientEncryptionStore, Provisioni
         let currentVersion = await this.getSchemaVersion();
         while (currentVersion < PgDatastore.LATEST_SCHEMA) {
             let newVersion = currentVersion + 1;
-            if (PgDatastore.LATEST_SCHEMA === 161) {
+            if (currentVersion === 16 && PgDatastore.LATEST_SCHEMA === 161) {
                 newVersion = 161;
             }
             if (currentVersion === 161) {

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -94,6 +94,11 @@ export class PgDatastore implements Datastore, ClientEncryptionStore, Provisioni
             userData as unknown as Record<string, string|undefined>) : null;
     }
 
+    public async getWporgUsername(slackUserId: string): Promise<string|null> {
+        const dbEntry = await this.postgresDb.oneOrNone("SELECT id FROM wporg_users WHERE slack_user_id = ${slackUserId}", { slackUserId });
+        return dbEntry ? dbEntry.id : null;
+    }
+
     public async getAllUsersForTeam(teamId: string): Promise<UserEntry[]> {
         const users = await this.postgresDb.manyOrNone("SELECT json FROM users WHERE json::json->>'team_id' = ${teamId}", {
             teamId,

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -95,8 +95,8 @@ export class PgDatastore implements Datastore, ClientEncryptionStore, Provisioni
     }
 
     public async getWporgUsername(slackUserId: string): Promise<string|null> {
-        const dbEntry = await this.postgresDb.oneOrNone("SELECT id FROM wporg_users WHERE slack_user_id = ${slackUserId}", { slackUserId });
-        return dbEntry ? dbEntry.id : null;
+        const dbEntry = await this.postgresDb.oneOrNone("SELECT wporg_id FROM wporg_users WHERE slack_id = ${slackUserId}", { slackUserId });
+        return dbEntry ? dbEntry.wporg_id : null;
     }
 
     public async getAllUsersForTeam(teamId: string): Promise<UserEntry[]> {

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -265,9 +265,12 @@ export class PgDatastore implements Datastore, ClientEncryptionStore, Provisioni
         const userMessages: SchemaRunUserMessage[] = [];
         let currentVersion = await this.getSchemaVersion();
         while (currentVersion < PgDatastore.LATEST_SCHEMA) {
-            log.info(`Updating schema to v${currentVersion + 1}`);
+            const newVersion = currentVersion + 1;
+            const newSchema = `./schema/v${newVersion}`;
+
+            log.info(`Updating schema to v${newVersion}`);
             // eslint-disable-next-line @typescript-eslint/no-var-requires
-            const runSchema: SchemaRunFn = require(`./schema/v${currentVersion + 1}`).runSchema;
+            const runSchema: SchemaRunFn = require(newSchema).runSchema;
             try {
                 const result = await runSchema(this.postgresDb);
                 if (result?.userMessages) {

--- a/src/datastore/postgres/schema/v161.ts
+++ b/src/datastore/postgres/schema/v161.ts
@@ -1,0 +1,15 @@
+import { IDatabase } from "pg-promise";
+
+export const runSchema = async(db: IDatabase<unknown>) => {
+    await db.none(`
+        create table wporg_users
+        (
+            id text not null
+                constraint wporg_users_pk
+                    primary key,
+            slack_user_id text not null
+                constraint wporg_users_slack_user_id
+                    unique
+        );
+    `);
+};

--- a/src/datastore/postgres/schema/v161.ts
+++ b/src/datastore/postgres/schema/v161.ts
@@ -4,11 +4,11 @@ export const runSchema = async(db: IDatabase<unknown>) => {
     await db.none(`
         create table wporg_users
         (
-            id text not null
+            wporg_id text not null
                 constraint wporg_users_pk
                     primary key,
-            slack_user_id text not null
-                constraint wporg_users_slack_user_id
+            slack_id text not null
+                constraint wporg_users_slack_id
                     unique
         );
     `);

--- a/wporg-users/.gitignore
+++ b/wporg-users/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!import-csv.sql

--- a/wporg-users/import-csv.sql
+++ b/wporg-users/import-csv.sql
@@ -1,0 +1,1 @@
+COPY wporg_users(slack_user_id, id) FROM '/usr/src/app/wporg-users/mapping.csv' WITH (FORMAT csv);

--- a/wporg-users/import-csv.sql
+++ b/wporg-users/import-csv.sql
@@ -1,1 +1,1 @@
-COPY wporg_users(slack_user_id, id) FROM '/usr/src/app/wporg-users/mapping.csv' WITH (FORMAT csv);
+COPY wporg_users(slack_id, wporg_id) FROM '/usr/src/app/wporg-users/mapping.csv' WITH (FORMAT csv);

--- a/yarn.lock
+++ b/yarn.lock
@@ -926,6 +926,13 @@ acorn@^8.8.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
+
 ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -1510,7 +1517,7 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -2595,6 +2602,14 @@ http-signature@~1.2.0:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
+
+https-proxy-agent@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 iconv-lite@0.4.24:
   version "0.4.24"


### PR DESCRIPTION
This PR makes the bridge post as an actual matrix user instead of a ghost user (`@slack_UABC123`) if an entry is found in the `wporg_users` table for the slack user id in question. If no entry is found in the `wporg_users` table, the bridge falls back to posting as the ghost user.

The `wporg_users` table must be filled by running an `.sql` script on the database. I have produced this script and have it locally but it isn't commited into the repo, for obvious reasons. It looks something like this:

```sql
insert into wporg_users (wporg_id, slack_id)
values
    ('foo', 'UABC123'),
    ('bar', 'UABC124');
```

I've opted for creating a database table for this purpose, as opposed to parsing a csv file, since that makes operations easier as we don't need to copy the `.csv` file into the bridge's container running in production. It also reduces complexity in the code by removing the need to parse csv. Additionally, having the information in the database means we can dynamically add users if need be, without needing to add a new `.csv` file to the bridge's container, and rebooting the bridge.

Requires changing the appservice configuration at the bridge and at the homeserver:

```yaml
rate_limited: false
namespaces:
  users:
    - exclusive: false
      regex: '@.*.*:community.wordpress.org'
```

## TODO

- [x] Verify that entries in `wporg_users` have the `wporg_id` escaped according to synapse rules, e.g. no leading `_`

## Test cases

- [x] Posts events from ghost matrix user when there is no matching wporg user
- [x] Posts events from wporg matrix user when there is a matching wporg user
    - [x] Registers new wporg matrix user 
    - [x] Uses existing wporg matrix user when there is one

## Screen capture

https://github.com/Automattic/matrix-appservice-slack/assets/550401/dce07ff2-f60d-467d-89cd-354abb5feb16

