### PR TITLE
Set external_url on messages sent to Matrix

### DIFF
--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -997,7 +997,7 @@ export class BridgedRoom {
             if (replyMEvent) {
                 replyMEvent = await this.stripMatrixReplyFallback(replyMEvent);
                 return await ghost.sendInThread(
-                    this.MatrixRoomId, message.text, this.slackTeamId, this.SlackChannelId!, eventTS, replyMEvent,
+                    this.MatrixRoomId, message.text, this.slackTeamId, this.SlackChannelId!, eventTS, replyMEvent, message.thread_ts,
                 );
             } else {
                 log.warn("Could not find matrix event for parent reply", message.thread_ts);

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -878,7 +878,7 @@ export class BridgedRoom {
                 formatted_body: `<a href="${link}">${file.name}</a>`,
                 msgtype: "m.text",
             };
-            await ghost.sendMessage(this.matrixRoomId, messageContent, channelId, slackEventId);
+            await ghost.sendMessage(this.matrixRoomId, messageContent, this.slackTeamId, channelId, slackEventId);
             return;
         }
 
@@ -917,7 +917,7 @@ export class BridgedRoom {
                 formatted_body: htmlCode,
                 msgtype: "m.text",
             };
-            await ghost.sendMessage(this.matrixRoomId, messageContent, channelId, slackEventId);
+            await ghost.sendMessage(this.matrixRoomId, messageContent, this.slackTeamId, channelId, slackEventId);
             return;
         }
 
@@ -952,6 +952,7 @@ export class BridgedRoom {
         await ghost.sendMessage(
             this.matrixRoomId,
             slackFileToMatrixMessage(file, fileContentUri, thumbnailContentUri),
+            this.slackTeamId,
             channelId,
             slackEventId,
         );
@@ -996,7 +997,7 @@ export class BridgedRoom {
             if (replyMEvent) {
                 replyMEvent = await this.stripMatrixReplyFallback(replyMEvent);
                 return await ghost.sendInThread(
-                    this.MatrixRoomId, message.text, this.SlackChannelId!, eventTS, replyMEvent,
+                    this.MatrixRoomId, message.text, this.slackTeamId, this.SlackChannelId!, eventTS, replyMEvent,
                 );
             } else {
                 log.warn("Could not find matrix event for parent reply", message.thread_ts);
@@ -1005,12 +1006,12 @@ export class BridgedRoom {
 
         // If we are only handling text, send the text. File messages are handled in a seperate block.
         if (["bot_message", "file_comment", undefined].includes(subtype) && message.files === undefined) {
-            return ghost.sendText(this.matrixRoomId, message.text!, channelId, eventTS);
+            return ghost.sendText(this.matrixRoomId, message.text!, this.slackTeamId, channelId, eventTS);
         } else if (subtype === "me_message") {
             return ghost.sendMessage(this.matrixRoomId, {
                 body: message.text!,
                 msgtype: "m.emote",
-            }, channelId, eventTS);
+            }, this.slackTeamId, channelId, eventTS);
         } else if (subtype === "message_changed") {
             const previousMessage = ghost.prepareBody(substitutions.slackToMatrix(message.previous_message!.text!));
             // We use message.text here rather than the proper message.message.text
@@ -1084,7 +1085,7 @@ export class BridgedRoom {
                 msgtype: "m.text",
                 ...replyContent,
             };
-            return ghost.sendMessage(this.MatrixRoomId, matrixContent, channelId, eventTS);
+            return ghost.sendMessage(this.MatrixRoomId, matrixContent, this.slackTeamId, channelId, eventTS);
         } else if (message.files) { // A message without a subtype can contain files.
             for (const file of message.files) {
                 try {
@@ -1097,7 +1098,7 @@ export class BridgedRoom {
             //   so we just send a separate `m.image` and `m.text` message
             // See https://github.com/matrix-org/matrix-doc/issues/906
             if (message.text) {
-                return ghost.sendText(this.matrixRoomId, message.text, channelId, eventTS);
+                return ghost.sendText(this.matrixRoomId, message.text, this.slackTeamId, channelId, eventTS);
             }
         } else if (message.subtype === "group_join" && message.user) {
             /* Private rooms don't send the usual join events so we listen for these */

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -743,7 +743,6 @@ export class Main {
         // Do not post echoes back to Slack.
         const existingEvent = await this.datastore.getEventByMatrixId(ev.room_id, ev.event_id);
         if (existingEvent) {
-            log.debug("Ignoring existing event", ev.event_id, ev.room_id);
             endTimer({outcome: "dropped"});
             return;
         }

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -414,7 +414,11 @@ export class SlackGhost {
         };
     }
 
-    private async urlForSlackEvent(slackTeamId: string | undefined, slackRoomId: string, slackEventTs: string): Promise<string | undefined> {
+    private async urlForSlackEvent(
+        slackTeamId: string | undefined,
+        slackRoomId: string,
+        slackEventTs: string
+    ): Promise<string | undefined> {
         if (!slackTeamId) {
             return;
         }

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -321,8 +321,13 @@ export class SlackGhost {
         return Slackdown.parse(body);
     }
 
-    public async sendInThread(roomId: string, text: string, slackRoomId: string,
-        slackEventTs: string, replyEvent: IMatrixReplyEvent): Promise<void> {
+    public async sendInThread(
+        roomId: string,
+        text: string,
+        slackRoomId: string,
+        slackEventTs: string,
+        replyEvent: IMatrixReplyEvent
+    ): Promise<void> {
         const content = {
             "m.relates_to": {
                 "rel_type": "m.thread",
@@ -368,7 +373,12 @@ export class SlackGhost {
         await this.sendMessage(roomId, content, slackRoomID, slackEventTS);
     }
 
-    public async sendMessage(roomId: string, msg: Record<string, unknown>, slackRoomId: string, slackEventTs: string): Promise<{event_id: string}> {
+    public async sendMessage(
+        roomId: string,
+        msg: Record<string, unknown>,
+        slackRoomId: string,
+        slackEventTs: string
+    ): Promise<{ event_id: string }> {
         if (!this._intent) {
             throw Error('No intent associated with ghost');
         }
@@ -390,8 +400,13 @@ export class SlackGhost {
         };
     }
 
-    public async sendReaction(roomId: string, eventId: string, key: string,
-        slackRoomId: string, slackEventTs: string): Promise<{event_id: string}> {
+    public async sendReaction(
+        roomId: string,
+        eventId: string,
+        key: string,
+        slackRoomId: string,
+        slackEventTs: string
+    ): Promise<{event_id: string}> {
         if (!this._intent) {
             throw Error('No intent associated with ghost');
         }
@@ -417,8 +432,13 @@ export class SlackGhost {
         };
     }
 
-    public async sendWithReply(roomId: string, text: string, slackRoomId: string,
-        slackEventTs: string, replyEvent: IMatrixReplyEvent): Promise<void> {
+    public async sendWithReply(
+        roomId: string,
+        text: string,
+        slackRoomId: string,
+        slackEventTs: string,
+        replyEvent: IMatrixReplyEvent
+    ): Promise<void> {
         const fallbackHtml = this.getFallbackHtml(roomId, replyEvent);
         const fallbackText = this.getFallbackText(replyEvent);
 

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -351,8 +351,8 @@ export class SlackGhost {
     public async sendText(
         roomId: string,
         text: string,
-        slackRoomID: string,
-        slackEventTS: string,
+        slackRoomId: string,
+        slackEventTs: string,
         extra: Record<string, unknown> = {}
     ): Promise<void> {
         // TODO: Slack's markdown is their own thing that isn't really markdown,
@@ -370,7 +370,7 @@ export class SlackGhost {
             msgtype: "m.text",
             ...extra,
         };
-        await this.sendMessage(roomId, content, slackRoomID, slackEventTS);
+        await this.sendMessage(roomId, content, slackRoomId, slackEventTs);
     }
 
     public async sendMessage(

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -324,6 +324,7 @@ export class SlackGhost {
     public async sendInThread(
         roomId: string,
         text: string,
+        slackTeamId: string | undefined,
         slackRoomId: string,
         slackEventTs: string,
         replyEvent: IMatrixReplyEvent
@@ -345,12 +346,13 @@ export class SlackGhost {
             "format": "org.matrix.custom.html",
             "formatted_body": this.prepareFormattedBody(text),
         };
-        await this.sendMessage(roomId, content, slackRoomId, slackEventTs);
+        await this.sendMessage(roomId, content, slackTeamId, slackRoomId, slackEventTs);
     }
 
     public async sendText(
         roomId: string,
         text: string,
+        slackTeamId: string | undefined,
         slackRoomId: string,
         slackEventTs: string,
         extra: Record<string, unknown> = {}
@@ -370,12 +372,13 @@ export class SlackGhost {
             msgtype: "m.text",
             ...extra,
         };
-        await this.sendMessage(roomId, content, slackRoomId, slackEventTs);
+        await this.sendMessage(roomId, content, slackTeamId, slackRoomId, slackEventTs);
     }
 
     public async sendMessage(
         roomId: string,
         msg: Record<string, unknown>,
+        slackTeamId: string | undefined,
         slackRoomId: string,
         slackEventTs: string
     ): Promise<{ event_id: string }> {
@@ -435,6 +438,7 @@ export class SlackGhost {
     public async sendWithReply(
         roomId: string,
         text: string,
+        slackTeamId: string | undefined,
         slackRoomId: string,
         slackEventTs: string,
         replyEvent: IMatrixReplyEvent
@@ -453,7 +457,7 @@ export class SlackGhost {
             "format": "org.matrix.custom.html",
             "formatted_body": fallbackHtml + this.prepareFormattedBody(text),
         };
-        await this.sendMessage(roomId, content, slackRoomId, slackEventTs);
+        await this.sendMessage(roomId, content, slackTeamId, slackRoomId, slackEventTs);
     }
 
     public async sendTyping(roomId: string): Promise<void> {

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -372,6 +372,7 @@ export class SlackGhost {
             msgtype: "m.text",
             ...extra,
         };
+
         await this.sendMessage(roomId, content, slackTeamId, slackRoomId, slackEventTs);
     }
 
@@ -386,9 +387,13 @@ export class SlackGhost {
             throw Error('No intent associated with ghost');
         }
 
-        const externalUrl = await this.urlForSlackEvent(slackTeamId, slackRoomId, slackEventTs);
-        if (externalUrl) {
-            msg.external_url = externalUrl;
+        // Set external_url, unless the msg already has one.
+        // When we're dealing with a message in a thread, the external_url will already have been set.
+        if (!msg.external_url) {
+            const externalUrl = await this.urlForSlackEvent(slackTeamId, slackRoomId, slackEventTs);
+            if (externalUrl) {
+                msg.external_url = externalUrl;
+            }
         }
 
         const matrixEvent = await this._intent.sendMessage(roomId, msg) as {event_id?: unknown};


### PR DESCRIPTION
This PR sets the `external_url` property on the matrix event, as per the [spec](https://spec.matrix.org/v1.3/application-service-api/#referencing-messages-from-a-third-party-network):

> Application services should include an external_url in the content of events it emits to indicate where the message came from. This typically applies to application services that bridge other networks into Matrix, such as IRC, where an HTTP URL may be available to reference.

The `external_url` property is set for both "normal" messages and messages in a thread:

- `https://${team.domain}.slack.com/archives/${slackRoomId}/p${slackEventTs}`
- `https://${team.domain}.slack.com/archives/${slackRoomId}/p${slackEventTs}?thread_ts=${slackThreadTs}`

