### PR TITLE
Export command

### DIFF
--- a/src/AdminCommands.ts
+++ b/src/AdminCommands.ts
@@ -140,6 +140,11 @@ export class AdminCommands {
                 respond: ResponseCallback,
                 team?: string,
             }) => {
+                if (!this.main.config.matrix_admin_room) {
+                    respond("matrix_admin_room must be set in the bridge config");
+                    return;
+                }
+
                 const quotemeta = (s: string) => s.replace(/\W/g, "\\$&");
                 let nameFilter: RegExp;
 
@@ -160,11 +165,6 @@ export class AdminCommands {
 
                 if (fileContent === "") {
                     respond("No rooms found");
-                    return;
-                }
-
-                if (!this.main.config.matrix_admin_room) {
-                    respond("matrix_admin_room is not set in the bridge config");
                     return;
                 }
 

--- a/src/AdminCommands.ts
+++ b/src/AdminCommands.ts
@@ -145,6 +145,12 @@ export class AdminCommands {
                     return;
                 }
 
+                const rooms = this.main.rooms.all;
+                if (rooms.length === 0) {
+                    respond("No rooms found");
+                    return;
+                }
+
                 const quotemeta = (s: string) => s.replace(/\W/g, "\\$&");
                 let nameFilter: RegExp;
 
@@ -153,20 +159,14 @@ export class AdminCommands {
                 }
 
                 let fileContent = "";
-                this.main.rooms.all.forEach((r) => {
+                rooms.forEach((r) => {
                     const channelName = r.SlackChannelName || "UNKNOWN";
-
                     if (nameFilter && !nameFilter.test(channelName)) {
                         return;
                     }
 
                     fileContent += `"${r.SlackChannelId}", "${r.MatrixRoomId}"\n`;
                 });
-
-                if (fileContent === "") {
-                    respond("No rooms found");
-                    return;
-                }
 
                 const filename = "bridge_mapping.csv";
                 fileContent = `slack_channel_id, bridged_matrix_room_id\n${fileContent}`;

--- a/src/AdminCommands.ts
+++ b/src/AdminCommands.ts
@@ -140,6 +140,8 @@ export class AdminCommands {
                 respond: ResponseCallback,
                 team?: string,
             }) => {
+                const filename = "bridge_mapping.csv";
+
                 if (!this.main.config.matrix_admin_room) {
                     respond("matrix_admin_room must be set in the bridge config");
                     return;
@@ -169,9 +171,7 @@ export class AdminCommands {
                     content += `\n"${r.SlackChannelId}", "${r.MatrixRoomId}"`;
                 });
 
-                const filename = "bridge_mapping.csv";
                 const contentUri = await this.main.botIntent.uploadContent(content, {name: filename});
-
                 await this.main.botIntent.sendEvent(this.main.config.matrix_admin_room, "m.room.message", {
                     body: filename,
                     info: {

--- a/src/AdminCommands.ts
+++ b/src/AdminCommands.ts
@@ -145,7 +145,7 @@ export class AdminCommands {
                     return;
                 }
 
-                const rooms = this.main.rooms.all;
+                let rooms = this.main.rooms.all;
                 if (rooms.length === 0) {
                     respond("No rooms found");
                     return;
@@ -157,12 +157,15 @@ export class AdminCommands {
                     nameFilter = new RegExp(`^${quoteMeta(team)}\\.#`);
                 }
 
+                rooms = rooms.filter(room => {
+                    if (!room.SlackChannelName || !nameFilter) {
+                        return true;
+                    }
+                    return !nameFilter.test(room.SlackChannelName);
+                });
+
                 let fileContent = "";
                 rooms.forEach((r) => {
-                    if (r.SlackChannelName && nameFilter && !nameFilter.test(r.SlackChannelName)) {
-                        return;
-                    }
-
                     fileContent += `"${r.SlackChannelId}", "${r.MatrixRoomId}"\n`;
                 });
 

--- a/src/AdminCommands.ts
+++ b/src/AdminCommands.ts
@@ -151,11 +151,10 @@ export class AdminCommands {
                     return;
                 }
 
-                const quotemeta = (s: string) => s.replace(/\W/g, "\\$&");
                 let nameFilter: RegExp;
-
                 if (team) {
-                    nameFilter = new RegExp(`^${quotemeta(team)}\\.#`);
+                    const quoteMeta = (s: string) => s.replace(/\W/g, "\\$&");
+                    nameFilter = new RegExp(`^${quoteMeta(team)}\\.#`);
                 }
 
                 let fileContent = "";

--- a/src/AdminCommands.ts
+++ b/src/AdminCommands.ts
@@ -164,7 +164,7 @@ export class AdminCommands {
                     return !nameFilter.test(room.SlackChannelName);
                 });
 
-                let content = "slack_channel_id, bridged_matrix_room_id";
+                let content = "slack_channel_id, matrix_room_id";
                 rooms.forEach((r) => {
                     content += `\n"${r.SlackChannelId}", "${r.MatrixRoomId}"`;
                 });

--- a/src/AdminCommands.ts
+++ b/src/AdminCommands.ts
@@ -159,8 +159,7 @@ export class AdminCommands {
 
                 let fileContent = "";
                 rooms.forEach((r) => {
-                    const channelName = r.SlackChannelName || "UNKNOWN";
-                    if (nameFilter && !nameFilter.test(channelName)) {
+                    if (r.SlackChannelName && nameFilter && !nameFilter.test(r.SlackChannelName)) {
                         return;
                     }
 

--- a/src/AdminCommands.ts
+++ b/src/AdminCommands.ts
@@ -135,12 +135,13 @@ export class AdminCommands {
     public get export(): AdminCommand {
         return new AdminCommand(
             "export",
-            "export the list of linked rooms as CSV",
-            async ({respond, team}: {
+            "export the list of linked rooms and their corresponding Slack channel id, as a CSV file",
+            async ({respond, file_name, team}: {
                 respond: ResponseCallback,
+                file_name?: string,
                 team?: string,
             }) => {
-                const filename = "bridge_mapping.csv";
+                const fileName = file_name ? `${file_name}.csv` : "bridge_mapping.csv";
 
                 if (!this.main.config.matrix_admin_room) {
                     respond("matrix_admin_room must be set in the bridge config");
@@ -171,9 +172,9 @@ export class AdminCommands {
                     content += `\n"${r.SlackChannelId}", "${r.MatrixRoomId}"`;
                 });
 
-                const contentUri = await this.main.botIntent.uploadContent(content, {name: filename});
+                const contentUri = await this.main.botIntent.uploadContent(content, {name: fileName});
                 await this.main.botIntent.sendEvent(this.main.config.matrix_admin_room, "m.room.message", {
-                    body: filename,
+                    body: fileName,
                     info: {
                         mimetype: "text/csv",
                     },
@@ -182,9 +183,13 @@ export class AdminCommands {
                 });
             },
             {
+                file_name: {
+                    alias: "F",
+                    description: "Name of the CSV file (optional)",
+                },
                 team: {
                     alias: "T",
-                    description: "Filter only rooms for this Slack team domain",
+                    description: "Filter only rooms for this Slack team domain (optional)",
                 },
             },
         );

--- a/src/AdminCommands.ts
+++ b/src/AdminCommands.ts
@@ -164,14 +164,13 @@ export class AdminCommands {
                     return !nameFilter.test(room.SlackChannelName);
                 });
 
-                let fileContent = "";
+                let content = "slack_channel_id, bridged_matrix_room_id";
                 rooms.forEach((r) => {
-                    fileContent += `"${r.SlackChannelId}", "${r.MatrixRoomId}"\n`;
+                    content += `\n"${r.SlackChannelId}", "${r.MatrixRoomId}"`;
                 });
 
                 const filename = "bridge_mapping.csv";
-                fileContent = `slack_channel_id, bridged_matrix_room_id\n${fileContent}`;
-                const contentUri = await this.main.botIntent.uploadContent(fileContent, {name: filename});
+                const contentUri = await this.main.botIntent.uploadContent(content, {name: filename});
 
                 await this.main.botIntent.sendEvent(this.main.config.matrix_admin_room, "m.room.message", {
                     body: filename,

--- a/wporg-users/.gitignore
+++ b/wporg-users/.gitignore
@@ -1,3 +1,0 @@
-*
-!.gitignore
-!import-csv.sql

--- a/wporg-users/import-csv.sql
+++ b/wporg-users/import-csv.sql
@@ -1,1 +1,0 @@
-COPY wporg_users(slack_id, wporg_id) FROM '/usr/src/app/wporg-users/mapping.csv' WITH (FORMAT csv);


### PR DESCRIPTION
Command for exporting the list of linked rooms and their corresponding Slack channel id, as a CSV file.

```
export - export the list of linked rooms and their corresponding Slack channel id, as a CSV file
  --file_name|-F - Name of the CSV file (optional)
  --team|-T - Filter only rooms for this Slack team domain (optional)
```