### PR TITLE
Do not set avatar or display name if user already has it set

### DIFF
--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -169,21 +169,8 @@ export class SlackGhost {
 
     private async updateDisplayname(message: {username?: string, user_name?: string, bot_id?: string, user_id?: string},
         client?: WebClient): Promise<boolean> {
-        let slackDisplayName = message.username || message.user_name;
         if (!this._intent) {
             throw Error('No intent associated with ghost');
-        }
-
-        if (client) { // We can be smarter if we have the bot.
-            if (message.bot_id && message.user_id) {
-                // In the case of operations on bots, we will have both a bot_id and a user_id.
-                // Ignore updating the displayname in this case.
-                return false;
-            } else if (message.bot_id) {
-                slackDisplayName = await this.getBotName(message.bot_id, client);
-            } else if (message.user_id) {
-                slackDisplayName = await this.getDisplayname(client);
-            }
         }
 
         let changed;
@@ -196,6 +183,19 @@ export class SlackGhost {
             this.displayname = matrixProfile.displayname;
             await this.datastore.upsertUser(this);
             return changed;
+        }
+
+        let slackDisplayName = message.username || message.user_name;
+        if (client) { // We can be smarter if we have the bot.
+            if (message.bot_id && message.user_id) {
+                // In the case of operations on bots, we will have both a bot_id and a user_id.
+                // Ignore updating the displayname in this case.
+                return false;
+            } else if (message.bot_id) {
+                slackDisplayName = await this.getBotName(message.bot_id, client);
+            } else if (message.user_id) {
+                slackDisplayName = await this.getDisplayname(client);
+            }
         }
 
         changed = this.displayname !== slackDisplayName;

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -175,7 +175,7 @@ export class SlackGhost {
 
         let changed;
         const matrixProfile = await this.intent.getProfileInfo(this.matrixUserId);
-        const hasDisplayName = matrixProfile.displayname && matrixProfile.displayname !== "";
+        const hasDisplayName = !!matrixProfile.displayname && matrixProfile.displayname !== "";
 
         // If matrix user already has a display name, we don't want to overwrite it with slack's display name.
         if (hasDisplayName) {
@@ -276,6 +276,18 @@ export class SlackGhost {
         if (!this._intent) {
             throw Error('No intent associated with ghost');
         }
+
+        const matrixProfile = await this.intent.getProfileInfo(this.matrixUserId);
+        const hasAvatar = !!matrixProfile.avatar_url && matrixProfile.avatar_url !== "";
+
+        // If matrix user already has an avatar, we don't want to overwrite it with slack's avatar.
+        if (hasAvatar) {
+            const changed = this.avatarHash !== matrixProfile.avatar_url;
+            this.avatarHash = matrixProfile.avatar_url;
+            await this.datastore.upsertUser(this);
+            return changed;
+        }
+
         let avatarUrl: string|undefined;
         let hash: string|undefined;
         if (message.bot_id && message.user_id) {

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -169,7 +169,7 @@ export class SlackGhost {
 
     private async updateDisplayname(message: {username?: string, user_name?: string, bot_id?: string, user_id?: string},
         client?: WebClient): Promise<boolean> {
-        let displayName = message.username || message.user_name;
+        let slackDisplayName = message.username || message.user_name;
         if (!this._intent) {
             throw Error('No intent associated with ghost');
         }
@@ -180,16 +180,16 @@ export class SlackGhost {
                 // Ignore updating the displayname in this case.
                 return false;
             } else if (message.bot_id) {
-                displayName = await this.getBotName(message.bot_id, client);
+                slackDisplayName = await this.getBotName(message.bot_id, client);
             } else if (message.user_id) {
-                displayName = await this.getDisplayname(client);
+                slackDisplayName = await this.getDisplayname(client);
             }
         }
 
-        const changed = this.displayname !== displayName;
-        log.debug(`Ensuring displayname ${displayName} for ${this.slackId}`);
-        await this._intent.ensureProfile(displayName);
-        this.displayname = displayName;
+        const changed = this.displayname !== slackDisplayName;
+        log.debug(`Ensuring displayname ${slackDisplayName} for ${this.slackId}`);
+        await this._intent.ensureProfile(slackDisplayName);
+        this.displayname = slackDisplayName;
         await this.datastore.upsertUser(this);
         return changed;
     }


### PR DESCRIPTION
- When matrix user already has a display name, do not set it to the slack's display name.
- When matrix user already has an avatar, do not set it to the slack's avatar.