### PR TITLE
Delete/edit message from Slack now deletes/edits on Matrix, and vice-versa

### DIFF
--- a/src/BaseSlackHandler.ts
+++ b/src/BaseSlackHandler.ts
@@ -83,6 +83,10 @@ export interface ISlackMessageEvent extends ISlackEvent {
     thread_ts?: string;
 }
 
+export interface ISlackMessageDeletedEvent extends Omit<ISlackMessageEvent, "deleted_ts"> {
+    deleted_ts: string;
+}
+
 export interface ISlackFile {
     name?: string;
     thumb_360?: string;

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -700,7 +700,8 @@ export class BridgedRoom {
                 await new Promise((r) => setTimeout(r, PUPPET_INCOMING_DELAY_MS));
             }
         }
-        if (this.recentSlackMessages.includes(message.ts)) {
+        const isMessageChangedEvent = message.subtype && message.subtype === 'message_changed';
+        if (!isMessageChangedEvent && this.recentSlackMessages.includes(message.ts)) {
             // We sent this, ignore.
             return;
         }
@@ -713,7 +714,7 @@ export class BridgedRoom {
             }
             this.slackSendLock = this.slackSendLock.then(() => {
                 // Check again
-                if (this.recentSlackMessages.includes(message.ts)) {
+                if (!isMessageChangedEvent && this.recentSlackMessages.includes(message.ts)) {
                     // We sent this, ignore
                     return;
                 }

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -14,7 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { BaseSlackHandler, ISlackEvent, ISlackMessageEvent, ISlackUser } from "./BaseSlackHandler";
+import {
+    BaseSlackHandler,
+    ISlackEvent,
+    ISlackMessageDeletedEvent,
+    ISlackMessageEvent,
+    ISlackUser
+} from "./BaseSlackHandler";
 import { BridgedRoom } from "./BridgedRoom";
 import { Main, METRIC_RECEIVED_MESSAGE } from "./Main";
 import { Logger } from "matrix-appservice-bridge";
@@ -294,14 +300,7 @@ export class SlackEventHandler extends BaseSlackHandler {
                 }
             }
         } else if (msg.subtype === "message_deleted" && msg.deleted_ts) {
-            const originalEvent = await this.main.datastore.getEventBySlackId(msg.channel, msg.deleted_ts);
-            if (originalEvent) {
-                const botClient = this.main.botIntent.matrixClient;
-                await botClient.redactEvent(originalEvent.roomId, originalEvent.eventId);
-                return;
-            }
-            // If we don't have the event
-            throw Error("unknown_message");
+            return await room.onSlackMessageDeleted(msg as ISlackMessageDeletedEvent);
         } else if (msg.subtype === "message_replied") {
             // Slack sends us one of these as well as a normal message event
             // when using RTM, so we ignore it.


### PR DESCRIPTION
At this moment, it's only expected that the operations work when done from the side the original message was sent from. For example, if you send a message from Slack, and try to delete it from Matrix, it will **not** delete it from Slack. This is expected at this point. If we want to support that use case, more work is needed.