### PR TITLE
Attach matrix eventId and roomId to slack event

### DIFF
--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -529,6 +529,15 @@ export class BridgedRoom {
             body.as_user = true;
             delete body.username;
         }
+
+        const metadata = {
+            event_type: "matrix_event",
+            event_payload: {
+                id: encodeURIComponent(message.event_id),
+                room_id: encodeURIComponent(message.room_id),
+            },
+        };
+
         let res: ChatPostMessageResponse;
         const chatPostMessageArgs = {
             ...body,
@@ -536,6 +545,7 @@ export class BridgedRoom {
             text: text || "",
             channel: this.slackChannelId!,
             unfurl_links: true,
+            metadata,
         };
 
         try {


### PR DESCRIPTION
When calling slack's history API, it requires setting `include_all_metadata=true` for it to return the `event_payload`, i.e. `https://foo.slack.com/api/conversations.history?include_all_metadata=true`.

Note `id` and `room_id` are URL-encoded.


<img width="817" alt="Screenshot 2023-07-12 at 17 40 31" src="https://github.com/Automattic/matrix-appservice-slack/assets/550401/efc9dfb9-a6eb-41be-b41f-2e663720b81e">


