### PR TITLE
Update display name and avatar of bots

### DIFF
--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -1040,7 +1040,7 @@ export class BridgedRoom {
             }
         }
 
-        // If we are only handling text, send the text. File messages are handled in a seperate block.
+        // If we are only handling text, send the text. File messages are handled in a separate block.
         if (["bot_message", "file_comment", undefined].includes(subtype) && message.files === undefined) {
             return ghost.sendText(this.matrixRoomId, message.text!, this.slackTeamId, channelId, eventTS);
         } else if (subtype === "me_message") {

--- a/src/MatrixUsernameStore.ts
+++ b/src/MatrixUsernameStore.ts
@@ -65,7 +65,7 @@ export class MatrixUsernameStore {
         const client = axios.create();
 
         const logError = (r: AxiosResponse | undefined) => {
-            log.warn("Failed to retrieve Matrix username:", r?.status, r?.statusText, r?.headers, r?.data);
+            log.warn(`Failed to retrieve Matrix username for ${slackUserId}:`, r?.status, r?.statusText, r?.headers, r?.data);
         };
 
         let response;

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -179,12 +179,13 @@ export class SlackGhost {
         let changed;
         const matrixProfile = await this.intent.getProfileInfo(this.matrixUserId);
         const matrixUsername = this.matrixUserId.slice(1, this.matrixUserId.indexOf(":"));
+        const isGhost = matrixUsername.startsWith(this.config.username_prefix);
         const hasDisplayName = !!matrixProfile.displayname
             && matrixProfile.displayname !== ""
             && matrixProfile.displayname !== matrixUsername;
 
         // If matrix user already has a display name, we don't want to overwrite it with slack's display name.
-        if (hasDisplayName) {
+        if (!isGhost && hasDisplayName) {
             changed = this.displayname !== matrixProfile.displayname;
             this.displayname = matrixProfile.displayname;
             await this.datastore.upsertUser(this);

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -21,6 +21,7 @@ import { WebClient } from "@slack/web-api";
 import { BotsInfoResponse, UsersInfoResponse } from "./SlackResponses";
 import { UserEntry, Datastore } from "./datastore/Models";
 import axios from "axios";
+import {IConfig} from "./IConfig";
 
 const log = new Logger("SlackGhost");
 
@@ -46,8 +47,9 @@ export class SlackGhost {
         return this.atime;
     }
 
-    public static fromEntry(datastore: Datastore, entry: UserEntry, intent?: Intent): SlackGhost {
+    public static fromEntry(config: IConfig, datastore: Datastore, entry: UserEntry, intent?: Intent): SlackGhost {
         return new SlackGhost(
+            config,
             datastore,
             entry.slack_id,
             entry.team_id,
@@ -63,6 +65,7 @@ export class SlackGhost {
     private userInfoLoading?: Promise<UsersInfoResponse>;
     private updateInProgress = false;
     constructor(
+        private readonly config: IConfig,
         private datastore: Datastore,
         public readonly slackId: string,
         public readonly teamId: string|undefined,

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -190,11 +190,7 @@ export class SlackGhost {
 
         let slackDisplayName = message.username || message.user_name;
         if (client) { // We can be smarter if we have the bot.
-            if (message.bot_id && message.user_id) {
-                // In the case of operations on bots, we will have both a bot_id and a user_id.
-                // Ignore updating the displayname in this case.
-                return false;
-            } else if (message.bot_id) {
+            if (message.bot_id) {
                 slackDisplayName = await this.getBotName(message.bot_id, client);
             } else if (message.user_id) {
                 slackDisplayName = await this.getDisplayname(client);

--- a/src/SlackGhostStore.ts
+++ b/src/SlackGhostStore.ts
@@ -54,7 +54,7 @@ export class SlackGhostStore {
 
     public async getNullGhostDisplayName(channel: string, userId: string): Promise<string> {
         const room = this.rooms.getBySlackChannelId(channel);
-        const nullGhost = new SlackGhost(this.datastore, userId, room!.SlackTeamId!, userId, undefined);
+        const nullGhost = new SlackGhost(this.config, this.datastore, userId, room!.SlackTeamId!, userId, undefined);
         if (!room || !room.SlackClient) {
             return userId;
         }
@@ -117,10 +117,11 @@ export class SlackGhostStore {
         let ghost: SlackGhost;
         if (entry) {
             log.debug("Got ghost entry from datastore", userId);
-            ghost = SlackGhost.fromEntry(this.datastore, entry, intent);
+            ghost = SlackGhost.fromEntry(this.config, this.datastore, entry, intent);
         } else {
             log.debug("Creating new ghost for", userId);
             ghost = new SlackGhost(
+                this.config,
                 this.datastore,
                 slackUserId,
                 teamId,
@@ -145,6 +146,6 @@ export class SlackGhostStore {
             return null;
         }
         const intent = this.bridge.getIntent(userId);
-        return SlackGhost.fromEntry(this.datastore, entry, intent);
+        return SlackGhost.fromEntry(this.config, this.datastore, entry, intent);
     }
 }

--- a/src/scripts/migrateToPostgres.ts
+++ b/src/scripts/migrateToPostgres.ts
@@ -168,7 +168,7 @@ export const migrateFromNedb = async(nedb: NedbDatastore, targetDs: Datastore): 
             user.slack_id = parts[1];
             user.team_id = existingTeam!.id;
         }
-        const ghost = SlackGhost.fromEntry(null as any, user);
+        const ghost = SlackGhost.fromEntry({} as any, null as any, user);
         await targetDs.upsertUser(ghost);
         log.info(`Migrated slack user ${user.id} (${i + 1}/${allSlackUsers.length})`);
     }));


### PR DESCRIPTION
This PR makes it so the bridge correctly sets the display name and avatar of the (ghost) Matrix user that corresponds to a Slack bot.