### PR TITLE
Fix line breaks

### DIFF
--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -393,10 +393,11 @@ export class SlackGhost {
         // TODO: This is fixing plaintext mentions, but should be refactored.
         // https://github.com/matrix-org/matrix-appservice-slack/issues/110
         const body = text.replace(/<https:\/\/matrix\.to\/#\/@.+:.+\|(.+)>/g, "$1");
+        const formattedBody = Slackdown.parse(text);
         const content = {
             body,
             format: "org.matrix.custom.html",
-            formatted_body: Slackdown.parse(text),
+            formatted_body: formattedBody,
             msgtype: "m.text",
             ...extra,
         };

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -393,7 +393,8 @@ export class SlackGhost {
         // but the only parser we have for it is slackdown. However, Matrix expects
         // a variant of markdown that is in the realm of sanity. Currently text
         // will be slack's markdown until we've got a slack -> markdown parser.
-        const formattedBody: string = Slackdown.parse(text);
+        let formattedBody: string = Slackdown.parse(text);
+        formattedBody = formattedBody.replace("\n", "<br>");
 
         const content = {
             body,

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -385,15 +385,16 @@ export class SlackGhost {
         slackEventTs: string,
         extra: Record<string, unknown> = {}
     ): Promise<void> {
+        // TODO: This is fixing plaintext mentions, but should be refactored.
+        // https://github.com/matrix-org/matrix-appservice-slack/issues/110
+        const body = text.replace(/<https:\/\/matrix\.to\/#\/@.+:.+\|(.+)>/g, "$1");
+
         // TODO: Slack's markdown is their own thing that isn't really markdown,
         // but the only parser we have for it is slackdown. However, Matrix expects
         // a variant of markdown that is in the realm of sanity. Currently text
         // will be slack's markdown until we've got a slack -> markdown parser.
+        const formattedBody: string = Slackdown.parse(text);
 
-        // TODO: This is fixing plaintext mentions, but should be refactored.
-        // https://github.com/matrix-org/matrix-appservice-slack/issues/110
-        const body = text.replace(/<https:\/\/matrix\.to\/#\/@.+:.+\|(.+)>/g, "$1");
-        const formattedBody = Slackdown.parse(text);
         const content = {
             body,
             format: "org.matrix.custom.html",


### PR DESCRIPTION
In some cases Element doesn't correctly render `\n` as a line break. Making it a `<br>` makes it always work.

Before and after:

<img width="164" alt="Screenshot 2023-08-17 at 16 21 00" src="https://github.com/Automattic/matrix-appservice-slack/assets/550401/ca1f8b9c-9597-4b5a-bc3c-7eb002d4987d">
