### PR TITLE
Parse block quotes

### DIFF
--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -414,7 +414,9 @@ export class SlackGhost {
             blocks.push(`<blockquote>${currentQuote}</blockquote>`);
         }
 
-        formattedBody = blocks.join("");
+        if (blocks.length > 0) {
+            formattedBody = blocks.join("");
+        }
         formattedBody = formattedBody.replace("\n", "<br>");
 
         const content = {

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -394,6 +394,24 @@ export class SlackGhost {
         // a variant of markdown that is in the realm of sanity. Currently text
         // will be slack's markdown until we've got a slack -> markdown parser.
         let formattedBody: string = Slackdown.parse(text);
+
+        // Parse blockquotes.
+        const blocks: string[] = [];
+        let currentQuote = "";
+        const quoteDelimiter = "> ";
+        for (const line of formattedBody.split("\n")) {
+            if (line.startsWith(quoteDelimiter)) {
+                currentQuote += line.replace(quoteDelimiter, "") + "<br>";
+            } else {
+                if (currentQuote !== "") {
+                    blocks.push(`<blockquote>${currentQuote}</blockquote>`);
+                }
+                blocks.push(`${line}<br>`);
+                currentQuote = "";
+            }
+        }
+
+        formattedBody = blocks.join("");
         formattedBody = formattedBody.replace("\n", "<br>");
 
         const content = {

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -410,6 +410,9 @@ export class SlackGhost {
                 currentQuote = "";
             }
         }
+        if (currentQuote !== "") {
+            blocks.push(`<blockquote>${currentQuote}</blockquote>`);
+        }
 
         formattedBody = blocks.join("");
         formattedBody = formattedBody.replace("\n", "<br>");


### PR DESCRIPTION
On slack:

<img width="160" alt="Screenshot 2023-08-17 at 17 08 26" src="https://github.com/Automattic/matrix-appservice-slack/assets/550401/ba7ee498-b310-4f1f-a341-5758b052d284">

On Matrix, before fix:

<img width="398" alt="Screenshot 2023-08-17 at 17 10 48" src="https://github.com/Automattic/matrix-appservice-slack/assets/550401/c5fea5bf-11c1-46a6-84a9-f46f7a5dcd8a">


On Matrix, after fix:

<img width="325" alt="Screenshot 2023-08-17 at 17 08 36" src="https://github.com/Automattic/matrix-appservice-slack/assets/550401/9cd04553-f694-4b69-800a-9a95de4b5f03">
