### PR TITLE
Support attachments with title, test and author

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,20 +5,20 @@ on:
 
 jobs:
   run-tests:
-   runs-on: ubuntu-latest
-   steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: 18
-    - run: yarn --pure-lockfile
-    - run: yarn test:unit
-    - run: yarn test:integration
-    - name: Run Postgres
-      run: |
-        docker run --detach --publish 5432:5432 \
-          --env POSTGRES_PASSWORD=pass \
-          --env POSTGRES_INITDB_ARGS="--lc-collate C --lc-ctype C --encoding UTF8" \
-          postgres
-    - run: yarn test:postgres
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: yarn --pure-lockfile
+      - run: yarn test:unit
+      - run: yarn test:integration
+      - name: Run Postgres
+        run: |
+          docker run --detach --publish 5432:5432 \
+            --env POSTGRES_PASSWORD=pass \
+            --env POSTGRES_INITDB_ARGS="--lc-collate C --lc-ctype C --encoding UTF8" \
+            postgres
+      - run: yarn test:postgres

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@slack/logger": "^3.0.0",
     "@slack/rtm-api": "^6.0.0",
     "@slack/web-api": "^6.7.2",
-    "Slackdown": "git+https://Half-Shot@github.com/half-shot/slackdown.git",
+    "slackdown": "^0.1.1",
     "ajv": "^8.12.0",
     "axios": "^0.27.2",
     "classnames": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "classnames": "^2.3.2",
     "escape-string-regexp": "^4.0.0",
     "https-proxy-agent": "^5.0.1",
+    "markdown-it": "^13.0.1",
     "matrix-appservice-bridge": "^8.1.2",
     "matrix-widget-api": "^1.1.1",
     "minimist": "^1.2.6",

--- a/src/BaseSlackHandler.ts
+++ b/src/BaseSlackHandler.ts
@@ -36,6 +36,7 @@ export interface ISlackEvent {
 
 export interface ISlackEventMessageAttachment {
     fallback: string;
+    pretext?: string;
     text?: string;
     title?: string;
     title_link?: string;

--- a/src/BaseSlackHandler.ts
+++ b/src/BaseSlackHandler.ts
@@ -37,6 +37,7 @@ export interface ISlackEvent {
 export interface ISlackEventMessageAttachment {
     fallback: string;
     text?: string;
+    title?: string;
     title_link?: string;
 }
 

--- a/src/BaseSlackHandler.ts
+++ b/src/BaseSlackHandler.ts
@@ -39,6 +39,7 @@ export interface ISlackEventMessageAttachment {
     text?: string;
     title?: string;
     title_link?: string;
+    author_name?: string;
 }
 
 export interface ISlackMessageEvent extends ISlackEvent {

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -1061,14 +1061,13 @@ export class BridgedRoom {
         }
 
         const parser = new SlackMessageParser(
-            this.MatrixRoomId,
             this.main.botIntent,
             this.main.datastore,
             this.main.rooms,
             this.main.ghostStore,
             this.main,
         );
-        const parsedMessage = await parser.parse(message, slackClient, lastEventInThread);
+        const parsedMessage = await parser.parse(message, slackClient);
         if (!parsedMessage) {
             log.warn(`Ignoring message with subtype: ${subtype}`);
             return;

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -28,12 +28,17 @@ const log = new Logger("SlackGhost");
 // How long in milliseconds to cache user info lookups.
 const USER_CACHE_TIMEOUT = 10 * 60 * 1000;  // 10 minutes
 
+export interface IMatrixEventContent {
+    msgtype: "m.text",
+    body: string;
+    format?: string;
+    formatted_body?: string;
+}
+
 export interface IMatrixReplyEvent {
     sender: string;
     event_id: string;
-    content: {
-        body: string;
-        formatted_body?: string;
+    content: IMatrixEventContent & {
         "m.relates_to"?: {
             rel_type?: string,
             event_id?: string,

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -347,7 +347,7 @@ export class SlackGhost {
         slackTeamId: string,
         slackChannelId: string,
         slackEventTs: string,
-        replyEvent: IMatrixReplyEvent,
+        lastEventInThread: IMatrixReplyEvent,
         slackThreadTs: string,
     ): Promise<void> {
         let msg: Record<string, unknown> = {
@@ -355,11 +355,11 @@ export class SlackGhost {
                 "rel_type": "m.thread",
                 // If the reply event is part of a thread, continue the thread.
                 // Otherwise, attach a thread to the reply event.
-                "event_id": replyEvent.content["m.relates_to"]?.event_id ?? replyEvent.event_id,
+                "event_id": lastEventInThread.content["m.relates_to"]?.event_id ?? lastEventInThread.event_id,
                 // Say that our reply is a thread fallback so clients that support threads can ignore it
                 "is_falling_back": true,
                 "m.in_reply_to": {
-                    event_id: replyEvent.event_id,
+                    event_id: lastEventInThread.event_id,
                 },
             },
             ...content,

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -121,6 +121,7 @@ export class SlackMessageParser {
         text += `${attachment.text}`;
 
         // Quote the whole attachment.
+        text = `> ${text}`;
         text = text.replaceAll("\n", "\n> ");
 
         return text;

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -215,6 +215,16 @@ export class SlackMessageParser {
             newFormattedBody = formattedFallback + parsedMessage.formatted_body;
         }
 
+        let relatesTo = {};
+        if (previousEvent) {
+            relatesTo = {
+                "m.relates_to": {
+                    rel_type: "m.replace",
+                    event_id: previousEvent.eventId,
+                },
+            };
+        }
+
         return {
             msgtype: "m.text",
             format: "org.matrix.custom.html",
@@ -225,7 +235,8 @@ export class SlackMessageParser {
                 format: "org.matrix.custom.html",
                 body: newBody,
                 formatted_body: newFormattedBody,
-            }
+            },
+            ...relatesTo,
         };
     }
 

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -124,6 +124,10 @@ export class SlackMessageParser {
         text = `> ${text}`;
         text = text.replaceAll("\n", "\n> ");
 
+        if (attachment.pretext) {
+            text = `${attachment.pretext}\n${text}`;
+        }
+
         return text;
     }
 

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -57,7 +57,7 @@ export class SlackMessageParser {
     async parse(
         message: ISlackMessageEvent,
         slackClient: WebClient,
-        replyEvent: IMatrixReplyEvent | null,
+        lastEventInThread: IMatrixReplyEvent | null,
     ): Promise<TextualMessageEventContent | null> {
         const subtype = message.subtype;
         if (!this.handledSubtypes.includes(subtype)) {
@@ -104,7 +104,7 @@ export class SlackMessageParser {
             }
 
             const parsedPreviousMessage = await this.doParse(message.previous_message.text, slackClient, message.channel, teamDomain);
-            return this.parseEdit(parsedMessage, parsedPreviousMessage, previousEvent, replyEvent);
+            return this.parseEdit(parsedMessage, parsedPreviousMessage, previousEvent, lastEventInThread);
         }
 
         return parsedMessage;
@@ -183,7 +183,7 @@ export class SlackMessageParser {
         parsedMessage: TextualMessageEventContent,
         parsedPreviousMessage: TextualMessageEventContent,
         previousEvent: EventEntry,
-        replyEvent: IMatrixReplyEvent | null
+        lastEventInThread: IMatrixReplyEvent | null
     ) {
         const edits  = substitutions.makeDiff(parsedPreviousMessage.body, parsedMessage.body);
         const prev   = substitutions.htmlEscape(edits.prev);
@@ -203,9 +203,9 @@ export class SlackMessageParser {
         let newBody = parsedMessage.body;
         let newFormattedBody = parsedMessage.formatted_body ?? "";
 
-        if (replyEvent) {
-            const bodyFallback = this.getFallbackText(replyEvent);
-            const formattedFallback = this.getFallbackHtml(this.matrixRoomId, replyEvent);
+        if (lastEventInThread) {
+            const bodyFallback = this.getFallbackText(lastEventInThread);
+            const formattedFallback = this.getFallbackHtml(this.matrixRoomId, lastEventInThread);
 
             body = `${bodyFallback}\n\n${body}`;
             formattedBody = formattedFallback + formattedBody;

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -123,6 +123,9 @@ export class SlackMessageParser {
             text += ` [${attachment.title_link}]`;
         }
 
+        // Quote the whole attachment.
+        text = text.replaceAll("\n", "\n> ");
+
         return text;
     }
 

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -119,9 +119,6 @@ export class SlackMessageParser {
         }
 
         text += `${attachment.text}`;
-        if (attachment.title_link) {
-            text += ` [${attachment.title_link}]`;
-        }
 
         // Quote the whole attachment.
         text = text.replaceAll("\n", "\n> ");

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -132,6 +132,9 @@ export class SlackMessageParser {
         // https://github.com/matrix-org/matrix-appservice-slack/issues/110
         body = body.replace(/<https:\/\/matrix\.to\/#\/@.+:.+\|(.+)>/g, "$1");
 
+        // Convert plain text body to HTML.
+        // We first run it through Slackdown, which will convert some elements to HTML.
+        // Then we pass it through the markdown renderer, while letting existing HTML through.
         let formattedBody: string = Slackdown.parse(body);
         formattedBody = this.markdown.render(formattedBody);
         formattedBody = formattedBody.replace("\n", "<br>");

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -1,5 +1,5 @@
 import {ISlackEventMessageAttachment, ISlackMessageEvent, ISlackFile} from "./BaseSlackHandler";
-import * as Slackdown from "Slackdown";
+import * as Slackdown from "slackdown";
 import {TextualMessageEventContent} from "matrix-bot-sdk/lib/models/events/MessageEvent";
 import substitutions, {getFallbackForMissingEmoji} from "./substitutions";
 import {IMatrixEventContent} from "./SlackGhost";

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -140,6 +140,14 @@ export class SlackMessageParser {
         formattedBody = this.markdown.render(formattedBody).trimEnd();
         formattedBody = formattedBody.replace("\n", "<br>");
 
+        if (formattedBody === `<p>${body}</p>`) {
+            // Formatted body is the same as plain text body, just wrapped in a paragraph.
+            return {
+                msgtype: "m.text",
+                body,
+            };
+        }
+
         return {
             msgtype: "m.text",
             format: "org.matrix.custom.html",

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -99,12 +99,13 @@ export class SlackMessageParser {
     }
 
     private parseAttachment(attachment: ISlackEventMessageAttachment): string {
-        let text = attachment.fallback;
-        if (attachment.text) {
-            text = `${text}: ${attachment.text}`;
-            if (attachment.title_link) {
-                text = `${text} [${attachment.title_link}]`;
-            }
+        if (!attachment.text) {
+            return attachment.fallback;
+        }
+
+        let text = `${attachment.text}`;
+        if (attachment.title_link) {
+            text += ` [${attachment.title_link}]`;
         }
 
         return text;

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -108,9 +108,9 @@ export class SlackMessageParser {
 
         if (attachment.title) {
             if (attachment.title_link) {
-                text += `# [${attachment.title}](${attachment.title_link})\n`;
+                text += `**[${attachment.title}](${attachment.title_link})**\n`;
             } else {
-                text += `# ${attachment.title}\n`;
+                text += `**${attachment.title}**\n`;
             }
         }
 

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -138,7 +138,7 @@ export class SlackMessageParser {
         // Then we pass it through the markdown renderer, while letting existing HTML through.
         let formattedBody: string = Slackdown.parse(body);
         formattedBody = this.markdown.render(formattedBody).trimEnd();
-        formattedBody = formattedBody.replace("\n", "<br>");
+        formattedBody = formattedBody.replaceAll("\n", "");
 
         if (formattedBody === `<p>${body}</p>`) {
             // Formatted body is the same as plain text body, just wrapped in a paragraph.

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -61,24 +61,23 @@ export class SlackMessageParser {
             };
         }
 
+        let text = "";
         if (message.attachments) {
             // noinspection LoopStatementThatDoesntLoopJS
             for (const attachment of message.attachments) {
-                message.text = attachment.fallback;
+                text = attachment.fallback;
                 if (attachment.text) {
-                    message.text = `${message.text}: ${attachment.text}`;
+                    text = `${text}: ${attachment.text}`;
                     if (attachment.title_link) {
-                        message.text = `${message.text} [${attachment.title_link}]`;
+                        text = `${text} [${attachment.title_link}]`;
                     }
                 }
                 break;
             }
-            if (message.text === "") {
-                return null;
-            }
+        } else {
+            text = message.text || "";
         }
 
-        let text = message.text;
         if (!text) {
             return null;
         }

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -48,8 +48,9 @@ export class SlackMessageParser {
     ) {
         this.markdown = new MarkdownIt({
             // Allow HTML to pass through as is.
-            // We're first passing the text through Slackdown, which will convert certain elements to HTML.
-            html: true
+            html: true,
+            // Convert \n to <br>.
+            breaks: true,
         });
     }
 
@@ -136,7 +137,7 @@ export class SlackMessageParser {
         // We first run it through Slackdown, which will convert some elements to HTML.
         // Then we pass it through the markdown renderer, while letting existing HTML through.
         let formattedBody: string = Slackdown.parse(body);
-        formattedBody = this.markdown.render(formattedBody);
+        formattedBody = this.markdown.render(formattedBody).trimEnd();
         formattedBody = formattedBody.replace("\n", "<br>");
 
         return {

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -191,27 +191,17 @@ export class SlackMessageParser {
         const before = substitutions.htmlEscape(edits.before);
         const after  = substitutions.htmlEscape(edits.after);
 
-        let body =
+        const body =
             `(edited) ${edits.before} ${edits.prev} ${edits.after} => ` +
             `${edits.before} ${edits.curr} ${edits.after}`;
 
-        let formattedBody =
+        const formattedBody =
             `<i>(edited)</i> ${before} <font color="red"> ${prev} </font> ${after} =&gt; ${before}` +
             `<font color="green"> ${curr} </font> ${after}`;
 
 
-        let newBody = parsedMessage.body;
-        let newFormattedBody = parsedMessage.formatted_body ?? "";
-
-        if (lastEventInThread) {
-            const bodyFallback = this.getFallbackText(lastEventInThread);
-            const formattedFallback = this.getFallbackHtml(this.matrixRoomId, lastEventInThread);
-
-            body = `${bodyFallback}\n\n${body}`;
-            formattedBody = formattedFallback + formattedBody;
-            newBody = bodyFallback + newBody;
-            newFormattedBody = formattedFallback + newFormattedBody;
-        }
+        const newBody = parsedMessage.body;
+        const newFormattedBody = parsedMessage.formatted_body ?? "";
 
         let relatesTo = {};
         if (previousEvent) {

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -61,9 +61,11 @@ export class SlackMessageParser {
             };
         }
 
-        let text: string;
+        let text = "";
         if (message.attachments) {
-            text = this.parseAttachments(message.attachments);
+            for (const attachment of message.attachments) {
+                text += this.parseAttachment(attachment);
+            }
         } else {
             text = message.text || "";
         }
@@ -87,19 +89,13 @@ export class SlackMessageParser {
         return parsedMessage;
     }
 
-    private parseAttachments(attachments: ISlackEventMessageAttachment[]): string {
-        let text = "";
-
-        // noinspection LoopStatementThatDoesntLoopJS
-        for (const attachment of attachments) {
-            text = attachment.fallback;
-            if (attachment.text) {
-                text = `${text}: ${attachment.text}`;
-                if (attachment.title_link) {
-                    text = `${text} [${attachment.title_link}]`;
-                }
+    private parseAttachment(attachment: ISlackEventMessageAttachment): string {
+        let text = attachment.fallback;
+        if (attachment.text) {
+            text = `${text}: ${attachment.text}`;
+            if (attachment.title_link) {
+                text = `${text} [${attachment.title_link}]`;
             }
-            break;
         }
 
         return text;

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -1,4 +1,4 @@
-import {ISlackFile, ISlackMessageEvent} from "./BaseSlackHandler";
+import {ISlackEventMessageAttachment, ISlackMessageEvent, ISlackFile} from "./BaseSlackHandler";
 import * as Slackdown from "Slackdown";
 import {TextualMessageEventContent} from "matrix-bot-sdk/lib/models/events/MessageEvent";
 import substitutions, {getFallbackForMissingEmoji} from "./substitutions";
@@ -61,24 +61,14 @@ export class SlackMessageParser {
             };
         }
 
-        let text = "";
+        let text: string;
         if (message.attachments) {
-            // noinspection LoopStatementThatDoesntLoopJS
-            for (const attachment of message.attachments) {
-                text = attachment.fallback;
-                if (attachment.text) {
-                    text = `${text}: ${attachment.text}`;
-                    if (attachment.title_link) {
-                        text = `${text} [${attachment.title_link}]`;
-                    }
-                }
-                break;
-            }
+            text = this.parseAttachments(message.attachments);
         } else {
             text = message.text || "";
         }
 
-        if (!text) {
+        if (text === "") {
             return null;
         }
 
@@ -95,6 +85,24 @@ export class SlackMessageParser {
         }
 
         return parsedMessage;
+    }
+
+    private parseAttachments(attachments: ISlackEventMessageAttachment[]): string {
+        let text = "";
+
+        // noinspection LoopStatementThatDoesntLoopJS
+        for (const attachment of attachments) {
+            text = attachment.fallback;
+            if (attachment.text) {
+                text = `${text}: ${attachment.text}`;
+                if (attachment.title_link) {
+                    text = `${text} [${attachment.title_link}]`;
+                }
+            }
+            break;
+        }
+
+        return text;
     }
 
     private async doParse(

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -105,12 +105,17 @@ export class SlackMessageParser {
         }
 
         let text = "";
+
         if (attachment.title) {
             if (attachment.title_link) {
                 text += `# [${attachment.title}](${attachment.title_link})\n`;
             } else {
                 text += `# ${attachment.title}\n`;
             }
+        }
+
+        if (attachment.author_name) {
+            text += `**${attachment.author_name}**\n`;
         }
 
         text += `${attachment.text}`;

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -74,7 +74,7 @@ export class SlackMessageParser {
         let text = "";
         if (message.attachments) {
             for (const attachment of message.attachments) {
-                text += this.parseAttachment(attachment);
+                text += this.parseAttachment(attachment) ?? "";
             }
         } else {
             text = message.text || "";

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -104,7 +104,16 @@ export class SlackMessageParser {
             return attachment.fallback;
         }
 
-        let text = `${attachment.text}`;
+        let text = "";
+        if (attachment.title) {
+            if (attachment.title_link) {
+                text += `# [${attachment.title}](${attachment.title_link})\n`;
+            } else {
+                text += `# ${attachment.title}\n`;
+            }
+        }
+
+        text += `${attachment.text}`;
         if (attachment.title_link) {
             text += ` [${attachment.title_link}]`;
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1727,6 +1727,11 @@ entities@^4.2.0, entities@^4.3.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
   integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
 
+entities@~3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
+  integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
+
 es-abstract@^1.19.0, es-abstract@^1.20.4:
   version "1.21.1"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.21.1.tgz#e6105a099967c08377830a0c9cb589d570dd86c6"
@@ -3011,6 +3016,13 @@ lilconfig@^2.0.5, lilconfig@^2.0.6:
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.6.tgz#32a384558bd58af3d4c6e077dd1ad1d397bc69d4"
   integrity sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==
 
+linkify-it@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-4.0.1.tgz#01f1d5e508190d06669982ba31a7d9f56a5751ec"
+  integrity sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==
+  dependencies:
+    uc.micro "^1.0.1"
+
 localforage@^1.3.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.10.0.tgz#5c465dc5f62b2807c3a84c0c6a1b1b3212781dd4"
@@ -3111,6 +3123,17 @@ make-error@^1.1.1:
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
+markdown-it@^13.0.1:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-13.0.1.tgz#c6ecc431cacf1a5da531423fc6a42807814af430"
+  integrity sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==
+  dependencies:
+    argparse "^2.0.1"
+    entities "~3.0.1"
+    linkify-it "^4.0.1"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
 matrix-appservice-bridge@^8.1.2:
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/matrix-appservice-bridge/-/matrix-appservice-bridge-8.1.2.tgz#30953a4599533fe61a0c37bd5500b654cd236e30"
@@ -3179,6 +3202,11 @@ matrix-widget-api@^1.1.1:
   dependencies:
     "@types/events" "^3.0.0"
     events "^3.2.0"
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -4611,6 +4639,11 @@ typescript@^4.4.3:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -865,10 +865,6 @@
     magic-string "^0.27.0"
     react-refresh "^0.14.0"
 
-"Slackdown@git+https://Half-Shot@github.com/half-shot/slackdown.git":
-  version "0.1.2"
-  resolved "git+https://Half-Shot@github.com/half-shot/slackdown.git#efd8934a3d9c3bf0064c0b217c5cf6b62ee697e4"
-
 a-sync-waterfall@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz#75b6b6aa72598b497a125e7a2770f14f4c8a1fa7"
@@ -4302,6 +4298,11 @@ simple-swizzle@^0.2.2:
   integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
   dependencies:
     is-arrayish "^0.3.1"
+
+slackdown@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/slackdown/-/slackdown-0.1.1.tgz#000e6baeb0d7fff155091a40a322dbad04af156a"
+  integrity sha512-Bp+y4dRODHqWr2XxVIid3qiHcNusR9R0hnRZYxJ/dZYwnoci1Gtg3ClylQNivYWk6DQ7jKNVptdeaGwhSlfktA==
 
 slash@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR improves rendering of slack [attachments](https://api.slack.com/messaging/composing/layouts#building-attachments). Not all fields are supported (e.g. images), but the most common ones should be.

This PR also includes some further refactors, and also fixes an issue that caused edits in threads to be posted as replies ([upstream issue](https://github.com/matrix-org/matrix-appservice-slack/issues/536)).

Additionally, we're now using a markdown parser, which simplifies a lot of things (e.g. don't need to parse blockquotes ourselves). 

## Screen captures
### On Matrix

<img width="533" alt="Screenshot 2023-09-01 at 17 01 55" src="https://github.com/Automattic/matrix-appservice-slack/assets/550401/e85f4bca-b33b-4b1c-86bc-591ce98b1d20">

----
### On Matrix, before this PR

<img width="678" alt="Screenshot 2023-09-01 at 17 02 56" src="https://github.com/Automattic/matrix-appservice-slack/assets/550401/a7d2110c-81c8-4c80-ae18-1d62c51dd957">

----
### On Slack
![265071459-ecd32878-fb7e-4f5b-b4a6-8397a1116586](https://github.com/Automattic/matrix-appservice-slack/assets/550401/b8ea1b57-a8cd-4d37-a425-a78d91a4c18e)





