### PR TITLE
Parse blocks

### DIFF
--- a/src/BaseSlackHandler.ts
+++ b/src/BaseSlackHandler.ts
@@ -41,6 +41,11 @@ export interface ISlackEventMessageAttachment {
     title?: string;
     title_link?: string;
     author_name?: string;
+    blocks?: ISlackEventMessageBlock[];
+}
+
+export interface ISlackEventMessageBlock {
+    type: string,
 }
 
 export interface ISlackMessageEvent extends ISlackEvent {
@@ -63,6 +68,7 @@ export interface ISlackMessageEvent extends ISlackEvent {
         user: string;
     };
     attachments?: ISlackEventMessageAttachment[];
+    blocks?: ISlackEventMessageBlock[];
     // For message_changed
     message?: ISlackMessageEvent;
     previous_message?: ISlackMessageEvent;

--- a/src/BaseSlackHandler.ts
+++ b/src/BaseSlackHandler.ts
@@ -49,6 +49,9 @@ export interface ISlackEventMessageBlock {
     text?: {
         text: string,
     }
+    fields?: [{
+        text: string,
+    }]
 }
 
 export interface ISlackMessageEvent extends ISlackEvent {

--- a/src/BaseSlackHandler.ts
+++ b/src/BaseSlackHandler.ts
@@ -46,6 +46,9 @@ export interface ISlackEventMessageAttachment {
 
 export interface ISlackEventMessageBlock {
     type: string,
+    text?: {
+        text: string,
+    }
 }
 
 export interface ISlackMessageEvent extends ISlackEvent {

--- a/src/BaseSlackHandler.ts
+++ b/src/BaseSlackHandler.ts
@@ -51,7 +51,10 @@ export interface ISlackEventMessageBlock {
     }
     fields?: [{
         text: string,
-    }]
+    }],
+    elements?: [{
+        text?: string,
+    }],
 }
 
 export interface ISlackMessageEvent extends ISlackEvent {

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -1028,7 +1028,6 @@ export class BridgedRoom {
 
         ghost.bumpATime();
         this.slackATime = Date.now() / 1000;
-
         const subtype = message.subtype;
 
         // Log activity, but don't await the answer or throw errors

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -172,9 +172,13 @@ export class SlackMessageParser {
                     content += `${field.text}\n`;
                 }
             }
+        } else if (type === "header") {
+            if (text) {
+                content += `# ${text.text}\n`;
+            }
         }
 
-        return content;
+        return `${content}\n`;
     }
 
     private async doParse(

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -160,12 +160,17 @@ export class SlackMessageParser {
     }
 
     private parseBlock(block: ISlackEventMessageBlock): string {
-        const {type, text} = block;
+        const {type, text, fields} = block;
         let content = "";
 
         if (type === "section") {
             if (text) {
                 content += `${text.text}\n`;
+            }
+            if (fields) {
+                for (const field of fields) {
+                    content += `${field.text}\n`;
+                }
             }
         }
 

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -160,7 +160,7 @@ export class SlackMessageParser {
     }
 
     private parseBlock(block: ISlackEventMessageBlock): string {
-        const {type, text, fields} = block;
+        const {type, text, fields, elements} = block;
         let content = "";
 
         switch (type) {
@@ -180,6 +180,15 @@ export class SlackMessageParser {
                 if (fields) {
                     for (const field of fields) {
                         content += `${field.text}\n`;
+                    }
+                }
+                break;
+            case "context":
+                if (elements) {
+                    for (const element of elements) {
+                        if (element.text) {
+                            content += `${element.text}\n`;
+                        }
                     }
                 }
                 break;

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -123,36 +123,37 @@ export class SlackMessageParser {
     }
 
     private parseAttachment(attachment: ISlackEventMessageAttachment): string {
+        const {blocks, pretext, text, fallback, title, title_link, author_name} = attachment;
         let content = "";
 
-        if (attachment.blocks) {
-            for (const block of attachment.blocks) {
+        if (blocks) {
+            for (const block of blocks) {
                 content += this.parseBlock(block);
             }
-        } else if (!attachment.text) {
-            content += attachment.fallback;
+        } else if (!text) {
+            content += fallback;
         } else {
-            if (attachment.title) {
-                if (attachment.title_link) {
-                    content += `**[${attachment.title}](${attachment.title_link})**\n`;
+            if (title) {
+                if (title_link) {
+                    content += `**[${title}](${title_link})**\n`;
                 } else {
-                    content += `**${attachment.title}**\n`;
+                    content += `**${title}**\n`;
                 }
             }
 
-            if (attachment.author_name) {
-                content += `**${attachment.author_name}**\n`;
+            if (author_name) {
+                content += `**${author_name}**\n`;
             }
 
-            content += `${attachment.text}`;
+            content += text;
         }
 
         // Quote the whole attachment.
         content = `> ${content}`;
         content = content.replaceAll("\n", "\n> ");
 
-        if (attachment.pretext) {
-            content = `${attachment.pretext}\n${content}`;
+        if (pretext) {
+            content = `${pretext}\n${content}`;
         }
 
         return content;

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -74,7 +74,9 @@ export class SlackMessageParser {
             for (const attachment of message.attachments) {
                 text += this.parseAttachment(attachment) ?? "";
             }
-        } else {
+        }
+
+        if (text === "") {
             text = message.text || "";
         }
 

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -125,8 +125,12 @@ export class SlackMessageParser {
     private parseAttachment(attachment: ISlackEventMessageAttachment): string {
         let text = "";
 
-        if (!attachment.text) {
-            text = attachment.fallback;
+        if (attachment.blocks) {
+            for (const block of attachment.blocks) {
+                text += this.parseBlock(block);
+            }
+        } else if (!attachment.text) {
+            text += attachment.fallback;
         } else {
             if (attachment.title) {
                 if (attachment.title_link) {

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -166,6 +166,10 @@ export class SlackMessageParser {
         if (type === "section") {
             if (text) {
                 content += `${text.text}\n`;
+                if (fields) {
+                    // If there's both text and fields, separate them with an empty line.
+                    content += "\n";
+                }
             }
             if (fields) {
                 for (const field of fields) {

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -123,39 +123,39 @@ export class SlackMessageParser {
     }
 
     private parseAttachment(attachment: ISlackEventMessageAttachment): string {
-        let text = "";
+        let content = "";
 
         if (attachment.blocks) {
             for (const block of attachment.blocks) {
-                text += this.parseBlock(block);
+                content += this.parseBlock(block);
             }
         } else if (!attachment.text) {
-            text += attachment.fallback;
+            content += attachment.fallback;
         } else {
             if (attachment.title) {
                 if (attachment.title_link) {
-                    text += `**[${attachment.title}](${attachment.title_link})**\n`;
+                    content += `**[${attachment.title}](${attachment.title_link})**\n`;
                 } else {
-                    text += `**${attachment.title}**\n`;
+                    content += `**${attachment.title}**\n`;
                 }
             }
 
             if (attachment.author_name) {
-                text += `**${attachment.author_name}**\n`;
+                content += `**${attachment.author_name}**\n`;
             }
 
-            text += `${attachment.text}`;
+            content += `${attachment.text}`;
         }
 
         // Quote the whole attachment.
-        text = `> ${text}`;
-        text = text.replaceAll("\n", "\n> ");
+        content = `> ${content}`;
+        content = content.replaceAll("\n", "\n> ");
 
         if (attachment.pretext) {
-            text = `${attachment.pretext}\n${text}`;
+            content = `${attachment.pretext}\n${content}`;
         }
 
-        return text;
+        return content;
     }
 
     private parseBlock(block: ISlackEventMessageBlock): string {

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -78,13 +78,13 @@ export class SlackMessageParser {
 
         if (message.blocks) {
             for (const block of message.blocks) {
-                text += this.parseBlock(block) ?? "";
+                text += this.parseBlock(block);
             }
         }
 
         if (message.attachments) {
             for (const attachment of message.attachments) {
-                text += this.parseAttachment(attachment) ?? "";
+                text += this.parseAttachment(attachment);
             }
         }
 

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -163,23 +163,26 @@ export class SlackMessageParser {
         const {type, text, fields} = block;
         let content = "";
 
-        if (type === "section") {
-            if (text) {
-                content += `${text.text}\n`;
+        switch (type) {
+            case "header":
+                if (text) {
+                    content += `# ${text.text}\n`;
+                }
+                break;
+            case "section":
+                if (text) {
+                    content += `${text.text}\n`;
+                    if (fields) {
+                        // If there's both text and fields, separate them with an empty line.
+                        content += "\n";
+                    }
+                }
                 if (fields) {
-                    // If there's both text and fields, separate them with an empty line.
-                    content += "\n";
+                    for (const field of fields) {
+                        content += `${field.text}\n`;
+                    }
                 }
-            }
-            if (fields) {
-                for (const field of fields) {
-                    content += `${field.text}\n`;
-                }
-            }
-        } else if (type === "header") {
-            if (text) {
-                content += `# ${text.text}\n`;
-            }
+                break;
         }
 
         return `${content}\n`;

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -1,4 +1,9 @@
-import {ISlackEventMessageAttachment, ISlackMessageEvent, ISlackFile} from "./BaseSlackHandler";
+import {
+    ISlackEventMessageAttachment,
+    ISlackMessageEvent,
+    ISlackFile,
+    ISlackEventMessageBlock
+} from "./BaseSlackHandler";
 import * as Slackdown from "slackdown";
 import {TextualMessageEventContent} from "matrix-bot-sdk/lib/models/events/MessageEvent";
 import substitutions, {getFallbackForMissingEmoji} from "./substitutions";
@@ -70,6 +75,13 @@ export class SlackMessageParser {
         }
 
         let text = "";
+
+        if (message.blocks) {
+            for (const block of message.blocks) {
+                text += this.parseBlock(block) ?? "";
+            }
+        }
+
         if (message.attachments) {
             for (const attachment of message.attachments) {
                 text += this.parseAttachment(attachment) ?? "";
@@ -140,6 +152,11 @@ export class SlackMessageParser {
         }
 
         return text;
+    }
+
+    private parseBlock(block: ISlackEventMessageBlock): string {
+        // TODO
+        return "";
     }
 
     private async doParse(

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -192,6 +192,9 @@ export class SlackMessageParser {
                     }
                 }
                 break;
+            case "divider":
+                content += `----\n`;
+                break;
         }
 
         return `${content}\n`;

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -123,25 +123,25 @@ export class SlackMessageParser {
     }
 
     private parseAttachment(attachment: ISlackEventMessageAttachment): string {
-        if (!attachment.text) {
-            return attachment.fallback;
-        }
-
         let text = "";
 
-        if (attachment.title) {
-            if (attachment.title_link) {
-                text += `**[${attachment.title}](${attachment.title_link})**\n`;
-            } else {
-                text += `**${attachment.title}**\n`;
+        if (!attachment.text) {
+            text = attachment.fallback;
+        } else {
+            if (attachment.title) {
+                if (attachment.title_link) {
+                    text += `**[${attachment.title}](${attachment.title_link})**\n`;
+                } else {
+                    text += `**${attachment.title}**\n`;
+                }
             }
-        }
 
-        if (attachment.author_name) {
-            text += `**${attachment.author_name}**\n`;
-        }
+            if (attachment.author_name) {
+                text += `**${attachment.author_name}**\n`;
+            }
 
-        text += `${attachment.text}`;
+            text += `${attachment.text}`;
+        }
 
         // Quote the whole attachment.
         text = `> ${text}`;

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -160,8 +160,16 @@ export class SlackMessageParser {
     }
 
     private parseBlock(block: ISlackEventMessageBlock): string {
-        // TODO
-        return "";
+        const {type, text} = block;
+        let content = "";
+
+        if (type === "section") {
+            if (text) {
+                content += `${text.text}\n`;
+            }
+        }
+
+        return content;
     }
 
     private async doParse(

--- a/src/SlackMessageParser.ts
+++ b/src/SlackMessageParser.ts
@@ -196,26 +196,18 @@ export class SlackMessageParser {
             `<i>(edited)</i> ${before} <font color="red"> ${prev} </font> ${after} =&gt; ${before}` +
             `<font color="green"> ${curr} </font> ${after}`;
 
-
         const newBody = parsedMessage.body;
         const newFormattedBody = parsedMessage.formatted_body ?? "";
-
-        let relatesTo = {};
-        if (previousEvent) {
-            relatesTo = {
-                "m.relates_to": {
-                    rel_type: "m.replace",
-                    event_id: previousEvent.eventId,
-                },
-            };
-        }
 
         return {
             ...this.makeEventContent(body, formattedBody),
             "m.new_content": {
                 ...this.makeEventContent(newBody, newFormattedBody),
             },
-            ...relatesTo,
+            "m.relates_to": {
+                rel_type: "m.replace",
+                event_id: previousEvent.eventId,
+            },
         };
     }
 


### PR DESCRIPTION
This PR parses `blocks`, both inside an attachment, and directly under the message. Supports all non-interactive, text [blocks](https://api.slack.com/reference/block-kit/blocks):

- header
- section
- context
- divider

## Screen captures

**Attachment with blocks:**

<img width="597" alt="Screenshot 2023-09-05 at 16 09 42" src="https://github.com/Automattic/matrix-appservice-slack/assets/550401/396a0efe-7676-417c-acb7-2447434722e9">

----
**Blocks directly (not in attachment):**

<img width="603" alt="Screenshot 2023-09-05 at 16 11 26" src="https://github.com/Automattic/matrix-appservice-slack/assets/550401/82816027-302b-4ecb-88c2-878c93c3118d">
