### PR TITLE
Team sync changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ In addition to all features of the upstream bridge, this fork adds the following
 - Fix issue that caused files sent to a thread on Slack to be posted on the main timeline on Matrix [[#20](https://github.com/Automattic/matrix-appservice-slack/pull/20)] [[upstream issue #671](https://github.com/matrix-org/matrix-appservice-slack/issues/671)]
 - Fix issue that caused channel name to not be displayed in the output of the `link` and `list` admin commands [[upstream fix #756](https://github.com/matrix-org/matrix-appservice-slack/pull/756)]
 
+## Team Sync Modifications
+
+- Don't update Slack ghost users upon every message as they are already handled in realtime under team sync.
+- Fix bug in membership change calculation when syncing channels upon boot.
+- Handle `channel_archive` slack event.
+- Define `rooms` field under teamsync config for who should be the creator, mods and admins in new rooms created by team sync.
+- Tweak message that gets posted in a new channel to suggest inviting `matrixbridge` Slack app.
+- Notify admins in admin room for bridge when bridge initialises upon boot, when a Slack channel is created/archived/deleted and unlinking of bridge fails upon channel archive/delete event.
+
 ## Usage
 
 This fork is a drop-in replacement for the upstream bridge, so the setup instructions are the same as upstream. The only difference is of course that you need to get the code from this fork:
@@ -158,12 +167,3 @@ The endpoint should respond with `401` when the secret doesn't match, `404` when
   "matrix": "janedoe"
 }
 ```
-
-## Team Sync Modifications
-
-- Don't update Slack ghost users upon every message as they are already handled in realtime under team sync
-- Fix bug in membership change calculation when syncing channels upon boot
-- Handle `channel_archive` slack event
-- Define `rooms` field under teamsync config for who should be the creator, mods and admins in new rooms created by team sync
-- Tweak message that gets posted in a new channel to suggest inviting `matrixbridge` Slack app
-- Notify admins in admin room for bridge when bridge initialises upon boot, when a Slack channel is created/archived/deleted and unlinking of bridge fails upon channel archive/delete event.

--- a/README.md
+++ b/README.md
@@ -158,3 +158,12 @@ The endpoint should respond with `401` when the secret doesn't match, `404` when
   "matrix": "janedoe"
 }
 ```
+
+## Team Sync Modifications
+
+- Don't update Slack ghost users upon every message as they are already handled in realtime under team sync
+- Fix bug in membership change calculation when syncing channels upon boot
+- Handle `channel_archive` slack event
+- Define `rooms` field under teamsync config for who should be the creator, mods and admins in new rooms created by team sync
+- Tweak message that gets posted in a new channel to suggest inviting `matrixbridge` Slack app
+- Notify admins in admin room for bridge when bridge initialises upon boot, when a Slack channel is created/archived/deleted and unlinking of bridge fails upon channel archive/delete event.

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -720,15 +720,15 @@ export class BridgedRoom {
             const ghost = await this.main.ghostStore.getForSlackMessage(message, this.slackTeamId);
             await ghost.cancelTyping(this.MatrixRoomId); // If they were typing, stop them from doing that.
 
-            let isTeamSyncEnabled = false;
+            let isTeamSyncEnabledForUsers = false;
             for (const team in this.main.config.team_sync) {
                 if (team === "all" || team === this.slackTeamId ) {
                     if (this.main.config.team_sync[team].users?.enabled) {
-                        isTeamSyncEnabled = true;
+                        isTeamSyncEnabledForUsers = true;
                     }
                 }
             }
-            if (!isTeamSyncEnabled) {
+            if (!isTeamSyncEnabledForUsers) {
                 const ghostChanged = await ghost.update(message, this.SlackClient);
                 if (ghostChanged) {
                     await this.main.fixDMMetadata(this, ghost);

--- a/src/BridgedRoom.ts
+++ b/src/BridgedRoom.ts
@@ -718,11 +718,23 @@ export class BridgedRoom {
         }
         try {
             const ghost = await this.main.ghostStore.getForSlackMessage(message, this.slackTeamId);
-            const ghostChanged = await ghost.update(message, this.SlackClient);
             await ghost.cancelTyping(this.MatrixRoomId); // If they were typing, stop them from doing that.
-            if (ghostChanged) {
-                await this.main.fixDMMetadata(this, ghost);
+
+            let isTeamSyncEnabled = false;
+            for (const team in this.main.config.team_sync) {
+                if (team === "all" || team === this.slackTeamId ) {
+                    if (this.main.config.team_sync[team].users?.enabled) {
+                        isTeamSyncEnabled = true;
+                    }
+                }
             }
+            if (!isTeamSyncEnabled) {
+                const ghostChanged = await ghost.update(message, this.SlackClient);
+                if (ghostChanged) {
+                    await this.main.fixDMMetadata(this, ghost);
+                }
+            }
+
             this.slackSendLock = this.slackSendLock.then(() => {
                 // Check again
                 if (!isMessageChangedEvent && this.recentSlackMessages.includes(message.ts)) {

--- a/src/IConfig.ts
+++ b/src/IConfig.ts
@@ -32,7 +32,6 @@ export interface IConfig {
     inbound_uri_prefix?: string;
     username_prefix: string;
 
-    super_admin_user?: string;
     matrix_admin_room?: string;
 
     rmau_limit?: number;

--- a/src/IConfig.ts
+++ b/src/IConfig.ts
@@ -32,6 +32,7 @@ export interface IConfig {
     inbound_uri_prefix?: string;
     username_prefix: string;
 
+    super_admin_user?: string;
     matrix_admin_room?: string;
 
     rmau_limit?: number;

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1289,13 +1289,7 @@ export class Main {
         }
 
         log.info("Bridge initialised");
-        // notify admins
-        if (this.config.matrix_admin_room) {
-            void this.botIntent.sendMessage(this.config.matrix_admin_room,{
-                msgtype: "m.notice",
-                body: "Bridge initialised",
-            });
-        }
+        await this.notifyAdmins("Bridge initialised");
 
         this.ready = true;
         return port;
@@ -1779,4 +1773,12 @@ export class Main {
         log.info("Enabled RTM");
     }
 
+    public async notifyAdmins(message: string) {
+        if (this.config.matrix_admin_room) {
+            await this.botIntent.sendMessage(this.config.matrix_admin_room, {
+                msgtype: "m.notice",
+                body: message,
+            });
+        }
+    }
 }

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -640,6 +640,19 @@ export class Main {
         return userIds.filter((i) => i.match(regexp));
     }
 
+    public async listGhostAndMappedUsers(roomId: string): Promise<string[]> {
+        const userIds = await this.listAllUsers(roomId);
+        const mappedUsernames = await this.datastore.getAllMatrixUsernames();
+
+        const mappedUsersSet = new Set();
+        for (const mappedUsername of mappedUsernames ?? []) {
+            mappedUsersSet.add("@" + mappedUsername + ":" + this.config.homeserver.server_name);
+        }
+
+        const regexp = new RegExp("^@" + this.config.username_prefix);
+        return userIds.filter((userId) => mappedUsersSet.has(userId) || userId.match(regexp));
+    }
+
     public async drainAndLeaveMatrixRoom(roomId: string): Promise<void> {
         const userIds = await this.listGhostUsers(roomId);
         log.info(`Draining ${userIds.length} ghosts from ${roomId}`);

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1289,6 +1289,14 @@ export class Main {
         }
 
         log.info("Bridge initialised");
+        // notify admins
+        if (this.config.matrix_admin_room) {
+            void this.botIntent.sendMessage(this.config.matrix_admin_room,{
+                msgtype: "m.notice",
+                body: "Bridge initialised",
+            });
+        }
+
         this.ready = true;
         return port;
     }

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1788,10 +1788,14 @@ export class Main {
 
     public async notifyAdmins(message: string) {
         if (this.config.matrix_admin_room) {
-            await this.botIntent.sendMessage(this.config.matrix_admin_room, {
-                msgtype: "m.notice",
-                body: message,
-            });
+            try {
+                await this.botIntent.sendMessage(this.config.matrix_admin_room, {
+                    msgtype: "m.notice",
+                    body: message,
+                });
+            } catch(ex) {
+                log.warn("failed to notify admins", message);
+            }
         }
     }
 }

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -211,7 +211,7 @@ export class SlackEventHandler extends BaseSlackHandler {
                 break;
             case "channel_created":
             case "channel_deleted":
-            case "channel_archived":
+            case "channel_archive":
             case "user_change":
             case "team_join":
                 await this.handleTeamSyncEvent(event as ISlackTeamSyncEvent, teamId);

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -113,8 +113,8 @@ export class SlackEventHandler extends BaseSlackHandler {
      * to events in order to handle them.
      */
     protected static SUPPORTED_EVENTS: string[] = ["message", "reaction_added", "reaction_removed",
-        "channel_created", "channel_deleted", "team_join"];
         "team_domain_change", "channel_rename", "user_change", "user_typing", "member_joined_channel", "member_left_channel",
+        "channel_created", "channel_deleted", "channel_archive", "team_join"];
     constructor(main: Main) {
         super(main);
     }

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -211,7 +211,6 @@ export class SlackEventHandler extends BaseSlackHandler {
                 break;
             case "channel_created":
             case "channel_deleted":
-            case "channel_archived":
             case "user_change":
             case "team_join":
                 await this.handleTeamSyncEvent(event as ISlackTeamSyncEvent, teamId);
@@ -242,6 +241,13 @@ export class SlackEventHandler extends BaseSlackHandler {
 
         if (event.bot_id && (event.bot_id === team.bot_id)) {
             return;
+        }
+
+        if (event.subtype === "channel_archive") {
+            if (this.main.teamSyncer) {
+                await this.main.teamSyncer.onChannelArchived(teamId, event.channel);
+                return;
+            }
         }
 
         if (event.subtype !== "message_deleted" && event.message && event.message.subtype === "tombstone") {
@@ -368,8 +374,6 @@ export class SlackEventHandler extends BaseSlackHandler {
             await this.main.teamSyncer.onChannelAdded(teamId, eventDetails.channel.id, eventDetails.channel.name, eventDetails.channel.creator);
         } else if (event.type === "channel_deleted") {
             await this.main.teamSyncer.onChannelDeleted(teamId, event.channel);
-        } else if (event.type === "channel_archive") {
-            await this.main.teamSyncer.onChannelArchived(teamId, event.channel);
         } else if (event.type === "team_join" || event.type === "user_change") {
             const user = event.user!;
             const domain = (await this.main.datastore.getTeam(teamId))!.domain;

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -211,6 +211,7 @@ export class SlackEventHandler extends BaseSlackHandler {
                 break;
             case "channel_created":
             case "channel_deleted":
+            case "channel_archived":
             case "user_change":
             case "team_join":
                 await this.handleTeamSyncEvent(event as ISlackTeamSyncEvent, teamId);
@@ -241,13 +242,6 @@ export class SlackEventHandler extends BaseSlackHandler {
 
         if (event.bot_id && (event.bot_id === team.bot_id)) {
             return;
-        }
-
-        if (event.subtype === "channel_archive") {
-            if (this.main.teamSyncer) {
-                await this.main.teamSyncer.onChannelArchived(teamId, event.channel);
-                return;
-            }
         }
 
         if (event.subtype !== "message_deleted" && event.message && event.message.subtype === "tombstone") {
@@ -374,6 +368,8 @@ export class SlackEventHandler extends BaseSlackHandler {
             await this.main.teamSyncer.onChannelAdded(teamId, eventDetails.channel.id, eventDetails.channel.name, eventDetails.channel.creator);
         } else if (event.type === "channel_deleted") {
             await this.main.teamSyncer.onChannelDeleted(teamId, event.channel);
+        } else if (event.type === "channel_archive") {
+            await this.main.teamSyncer.onChannelArchived(teamId, event.channel);
         } else if (event.type === "team_join" || event.type === "user_change") {
             const user = event.user!;
             const domain = (await this.main.datastore.getTeam(teamId))!.domain;

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -113,8 +113,8 @@ export class SlackEventHandler extends BaseSlackHandler {
      * to events in order to handle them.
      */
     protected static SUPPORTED_EVENTS: string[] = ["message", "reaction_added", "reaction_removed",
-        "team_domain_change", "channel_rename", "user_change", "user_typing", "member_joined_channel",
         "channel_created", "channel_deleted", "team_join"];
+        "team_domain_change", "channel_rename", "user_change", "user_typing", "member_joined_channel", "member_left_channel",
     constructor(main: Main) {
         super(main);
     }

--- a/src/SlackEventHandler.ts
+++ b/src/SlackEventHandler.ts
@@ -211,6 +211,7 @@ export class SlackEventHandler extends BaseSlackHandler {
                 break;
             case "channel_created":
             case "channel_deleted":
+            case "channel_archived":
             case "user_change":
             case "team_join":
                 await this.handleTeamSyncEvent(event as ISlackTeamSyncEvent, teamId);
@@ -367,6 +368,8 @@ export class SlackEventHandler extends BaseSlackHandler {
             await this.main.teamSyncer.onChannelAdded(teamId, eventDetails.channel.id, eventDetails.channel.name, eventDetails.channel.creator);
         } else if (event.type === "channel_deleted") {
             await this.main.teamSyncer.onChannelDeleted(teamId, event.channel);
+        } else if (event.type === "channel_archive") {
+            await this.main.teamSyncer.onChannelArchived(teamId, event.channel);
         } else if (event.type === "team_join" || event.type === "user_change") {
             const user = event.user!;
             const domain = (await this.main.datastore.getTeam(teamId))!.domain;

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -512,8 +512,8 @@ export class TeamSyncer {
                 try {
                     await client.chat.postEphemeral({
                         user: channelItem.creator,
-                        text: `Please invite \`@${user.name}\` app to this channel (\`/invite @${user.name}\`) so that ` +
-                            `this channel is also available on Matrix side.`,
+                        text: `Please invite \`@${user.name}\` to this channel (\`/invite @${user.name}\`) so that ` +
+                            `the channel is also available on Matrix.`,
                         channel: channelItem.id,
                     });
                 } catch (error) {

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -423,6 +423,7 @@ export class TeamSyncer {
             await this.main.actionUnlink({ matrix_room_id: roomId });
         } catch (ex) {
             log.warn("Tried to unlink room but failed:", ex);
+            await this.main.notifyAdmins(`failed to unlink bridge on ${roomId}`);
         }
     }
 

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -409,7 +409,7 @@ export class TeamSyncer {
                 body: `The Slack channel bridged to this room has been '${reason}'.`,
             });
         } catch (ex) {
-            log.warn(`Failed to send \`${reason}\` notice into the room:`, ex);
+            log.warn(`Failed to send '${reason}' notice into the room:`, ex);
         }
 
         // Hide from room directory.

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -553,6 +553,7 @@ export class TeamSyncer {
                 mods = teamConfig?.rooms?.moderators;
                 admins = teamConfig?.rooms?.administrators;
                 matrixCreator = teamConfig?.rooms?.creator;
+                break;
             }
         }
 

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -484,7 +484,8 @@ export class TeamSyncer {
                 try {
                     await client.chat.postEphemeral({
                         user: channelItem.creator,
-                        text: `Hint: To bridge to Matrix, run the \`/invite @${user.name}\` command in this channel.`,
+                        text: `Please invite \`@${user.name}\` app to this channel (\`/invite @${user.name}\`) so that ` +
+                            `this channel is also available on Matrix side.`,
                         channel: channelItem.id,
                     });
                 } catch (error) {

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -586,13 +586,7 @@ export class TeamSyncer {
                 intent = this.main.botIntent;
             }
         }
-        const aliasPrefix = this.getAliasPrefix(teamId);
-        const alias = aliasPrefix ? `${aliasPrefix}${channel.name.toLowerCase()}` : undefined;
-        let topic: undefined|string;
-        if (channel.purpose) {
-            topic = channel.purpose.value;
-        }
-        log.debug("Creating new room for channel", channel.name, topic, alias);
+
         const plUsers = {};
         for (const mod of mods ?? []) {
             plUsers[mod] = 50;
@@ -600,6 +594,15 @@ export class TeamSyncer {
         for (const admin of admins ?? []) {
             plUsers[admin] = 100;
         }
+
+        const aliasPrefix = this.getAliasPrefix(teamId);
+        const alias = aliasPrefix ? `${aliasPrefix}${channel.name.toLowerCase()}` : undefined;
+        let topic: undefined|string;
+        if (channel.purpose) {
+            topic = channel.purpose.value;
+        }
+
+        log.debug("Creating new room for channel", channel.name, topic, alias);
         inviteList = inviteList.filter((s) => s !== creatorUserId || s !== this.main.botUserId);
         inviteList.push(this.main.botUserId);
         const extraContent: Record<string, unknown>[] = [];

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -231,6 +231,14 @@ export class TeamSyncer {
         const client = await this.main.clientFactory.getTeamClient(teamId);
         const { channel } = (await client.conversations.info({ channel: channelId })) as ConversationsInfoResponse;
         await this.syncChannel(teamId, channel);
+        const room = this.main.rooms.getBySlackChannelId(channelId);
+        if (!room) {
+            log.warn(`No bridged room found for new channel (${channelId}) after sync`);
+            await this.notifyAdmins(`${teamId} created channel ${channelId} but problem creating a bridge`);
+            return;
+        }
+
+        await this.notifyAdmins(`${teamId} created channel ${channelId}, bridged room: ${room.MatrixRoomId}`);
     }
 
     public async onDiscoveredPrivateChannel(teamId: string, client: WebClient, chanInfo: ConversationsInfoResponse): Promise<void> {

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -234,11 +234,11 @@ export class TeamSyncer {
         const room = this.main.rooms.getBySlackChannelId(channelId);
         if (!room) {
             log.warn(`No bridged room found for new channel (${channelId}) after sync`);
-            await this.notifyAdmins(`${teamId} created channel ${channelId} but problem creating a bridge`);
+            await this.main.notifyAdmins(`${teamId} created channel ${channelId} but problem creating a bridge`);
             return;
         }
 
-        await this.notifyAdmins(`${teamId} created channel ${channelId}, bridged room: ${room.MatrixRoomId}`);
+        await this.main.notifyAdmins(`${teamId} created channel ${channelId}, bridged room: ${room.MatrixRoomId}`);
     }
 
     public async onDiscoveredPrivateChannel(teamId: string, client: WebClient, chanInfo: ConversationsInfoResponse): Promise<void> {
@@ -383,7 +383,7 @@ export class TeamSyncer {
             return;
         }
 
-        await this.notifyAdmins(`${teamId} removed channel ${channelId}, bridged room: ${room.MatrixRoomId}`);
+        await this.main.notifyAdmins(`${teamId} removed channel ${channelId}, bridged room: ${room.MatrixRoomId}`);
         await this.shutDownBridgedRoom("deleted", room.MatrixRoomId);
     }
 
@@ -398,17 +398,8 @@ export class TeamSyncer {
             return;
         }
 
-        await this.notifyAdmins(`${teamId} archived channel ${channelId}, bridged room: ${room.MatrixRoomId}`);
+        await this.main.notifyAdmins(`${teamId} archived channel ${channelId}, bridged room: ${room.MatrixRoomId}`);
         await this.shutDownBridgedRoom("archived", room.MatrixRoomId);
-    }
-
-    public async notifyAdmins(message: string) {
-        if (this.adminRoom) {
-            await this.main.botIntent.sendMessage(this.adminRoom, {
-                msgtype: "m.notice",
-                body: message,
-            });
-        }
     }
 
     public async shutDownBridgedRoom(reason: string, roomId: string) {

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -374,7 +374,7 @@ export class TeamSyncer {
         if (this.adminRoom) {
             await this.main.botIntent.sendMessage(this.adminRoom, {
                 msgtype: "m.notice",
-                body: `${teamId} removed channel ${channelId}`,
+                body: `${teamId} removed channel ${channelId}, bridged room: ${room.MatrixRoomId}`,
             });
         }
 

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -406,7 +406,7 @@ export class TeamSyncer {
         try {
             await this.main.botIntent.sendMessage(roomId, {
                 msgtype: "m.notice",
-                body: `The Slack channel bridged to this room has been \`${reason}\`.`,
+                body: `The Slack channel bridged to this room has been '${reason}'.`,
             });
         } catch (ex) {
             log.warn(`Failed to send \`${reason}\` notice into the room:`, ex);

--- a/src/datastore/Models.ts
+++ b/src/datastore/Models.ts
@@ -98,6 +98,7 @@ export interface Datastore extends ProvisioningStore {
     getMatrixUser(userId: string): Promise<MatrixUser|null>;
     getMatrixUsername(slackUserId: string): Promise<string|null>;
     setMatrixUsername(slackUserId: string, matrixUsername: string): Promise<null>;
+    getAllMatrixUsernames(): Promise<string[]>;
     storeMatrixUser(user: MatrixUser): Promise<null>;
     getAllUsersForTeam(teamId: string): Promise<UserEntry[]>;
 

--- a/src/datastore/NedbDatastore.ts
+++ b/src/datastore/NedbDatastore.ts
@@ -172,6 +172,10 @@ export class NedbDatastore implements Datastore {
         throw Error("method not implemented");
     }
 
+    public async getAllMatrixUsernames(): Promise<string[]> {
+        throw Error("method not implemented");
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public async setMatrixUsername(slackUserId: string, matrixUsername: string): Promise<null> {
         throw Error("method not implemented");

--- a/src/datastore/postgres/PgDatastore.ts
+++ b/src/datastore/postgres/PgDatastore.ts
@@ -113,6 +113,13 @@ export class PgDatastore implements Datastore, ClientEncryptionStore, Provisioni
         );
     }
 
+    public async getAllMatrixUsernames(): Promise<string[]> {
+        const all = await this.postgresDb.manyOrNone(
+            "SELECT matrix_username FROM matrix_usernames"
+        );
+        return all.map((dbEntry) => dbEntry ? dbEntry.matrix_username : null);
+    }
+
     public async getAllUsersForTeam(teamId: string): Promise<UserEntry[]> {
         const users = await this.postgresDb.manyOrNone("SELECT json FROM users WHERE json::json->>'team_id' = ${teamId}", {
             teamId,

--- a/tests/utils/fakeDatastore.ts
+++ b/tests/utils/fakeDatastore.ts
@@ -214,4 +214,8 @@ export class FakeDatastore implements Datastore {
     async setMatrixUsername(slackUserId: string, matrixUsername: string): Promise<null> {
         throw new Error("Method not implemented.");
     }
+
+    async getAllMatrixUsernames(): Promise<string[]> {
+        throw new Error("Method not implemented.");
+    }
 }


### PR DESCRIPTION
This PR changes the team sync behavior in following ways:

- Don't update slack ghost users upon every message as they are already handled in realtime under team sync
- Fix bug in membership change calculation when syncing channels upon boot
- Handle `channel_archive` slack event
- Define `rooms` field under teamsync config for who should be the creator, mods and admins in new rooms created by team sync
- Tweak message that gets posted in a new channel to suggest inviting `matrixbridge` app
- Notify admins in admin room for bridge when bridge initialises upon boot, when a slack channel is created/archived/deleted and unlinking of bridge fails upon channel archive/delete event.

Plan to get this deployed:

1) Review PR (@psrpinto)
2) Deploy it on staging to test
3) Deploy on prod