### PR TITLE
Change Team sync to prefer slack profile's real name opposed to display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ In addition to all features of the upstream bridge, this fork adds the following
 - Define `rooms` field under teamsync config for who should be the creator, mods and admins in new rooms created by team sync.
 - Tweak message that gets posted in a new channel to suggest inviting `matrixbridge` Slack app.
 - Notify admins in admin room for bridge when bridge initialises upon boot, when a Slack channel is created/archived/deleted and unlinking of bridge fails upon channel archive/delete event.
+- When user is synced, Slack's real name is preferred over display name and updated on user's profile on Matrix
 
 ## Usage
 

--- a/src/SlackGhost.ts
+++ b/src/SlackGhost.ts
@@ -147,9 +147,9 @@ export class SlackGhost {
             throw Error('No intent associated with ghost');
         }
         let changed = false;
-        if (slackUser.profile.display_name && this.displayName !== slackUser.profile.display_name) {
-            await this._intent.setDisplayName(slackUser.profile.display_name);
-            this.displayname = slackUser.profile.display_name;
+        if (slackUser.profile.real_name && this.displayName !== slackUser.profile.real_name) {
+            await this._intent.setDisplayName(slackUser.profile.real_name);
+            this.displayname = slackUser.profile.real_name;
             changed = true;
         }
 


### PR DESCRIPTION
Enabling team sync updated matrix users' name since it defaults to Slack's display name. In prod, we had real name as the display name which enabled mentioning users work both by their username and name. In order to bring this back, change in this PR changes how users are synced.

This change would ensure anytime a user is synced (at boot or with user_change event), slack's profile real name for the user is set as the name on its corresponding matrix account, if it doesn't match already.

@psrpinto I was able to test this locally and it worked, but please take a closer look. Here's it in action:

![Screenshot 2023-11-21 at 8 59 39 PM](https://github.com/Automattic/matrix-appservice-slack/assets/858906/1060cea0-a973-4770-9c76-7624b1ff97f8)

