### PR TITLE
Teamsync fix to dynamically create rooms

### DIFF
--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -618,8 +618,8 @@ export class TeamSyncer {
         }
 
         // Important note: default alias needs to be undefined if alias prefix isn't used
-        // otherwise teamsync would fail to create new room since if room alias is specified,
-        // it needs to have exclusive access to such rooms (configured in app service config)
+        // otherwise Synapse refuses to create the room even when room alias is specified, as if it wasn't specified
+        // Seems like a bug but looking at Synapse's code, I couldn't find what's wrong
         const aliasPrefix = this.getAliasPrefix(teamId);
         const alias = aliasPrefix ? `${aliasPrefix}${channel.name.toLowerCase()}` : undefined;
         let topic: undefined|string;

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -617,6 +617,9 @@ export class TeamSyncer {
             plUsers[admin] = 100;
         }
 
+        // Important note: default alias needs to be undefined if alias prefix isn't used
+        // otherwise teamsync would fail to create new room since if room alias is specified,
+        // it needs to have exclusive access to such rooms (configured in app service config)
         const aliasPrefix = this.getAliasPrefix(teamId);
         const alias = aliasPrefix ? `${aliasPrefix}${channel.name.toLowerCase()}` : undefined;
         let topic: undefined|string;

--- a/src/TeamSyncer.ts
+++ b/src/TeamSyncer.ts
@@ -618,7 +618,7 @@ export class TeamSyncer {
         }
 
         const aliasPrefix = this.getAliasPrefix(teamId);
-        const alias = aliasPrefix ? `${aliasPrefix}${channel.name.toLowerCase()}` : channel.name.toLowerCase();
+        const alias = aliasPrefix ? `${aliasPrefix}${channel.name.toLowerCase()}` : undefined;
         let topic: undefined|string;
         if (channel.purpose) {
             topic = channel.purpose.value;


### PR DESCRIPTION
This PR reverts a previous change regarding default room alias for rooms created under team sync.

Apparently it needs to be `undefined`, otherwise when defined, Synapse refuses to create the room as if that room alias isn't defined in appservice config, even when it is (irrespective of value of `exclusive`).

I couldn't find anything wrong in [Synapse's code](https://github.com/matrix-org/synapse/blob/b0ed14d8156e611a5f8ee772e69e171bd645820c/synapse/handlers/directory.py#L135) where this error is throw `This application service has not reserved this kind of alias.` but something seems off.