### PR TITLE
Ignore certain matrix events

### DIFF
--- a/src/Main.ts
+++ b/src/Main.ts
@@ -757,6 +757,11 @@ export class Main {
             return;
         }
 
+        // ignore events which have slack_bridge_ignore property in content field set as True
+        if (ev.content["org.wordpress.slack_bridge_ignore"] !== undefined && ev.content["org.wordpress.slack_bridge_ignore"] === true) {
+            return;
+        }
+
         this.incCounter(METRIC_RECEIVED_MESSAGE, {side: "matrix"});
         const endTimer = this.startTimer("matrix_request_seconds");
 


### PR DESCRIPTION
This PR introduces a change to ignore certain events which have `org.wordpress.slack_bridge_ignore` property in content field set as `True`